### PR TITLE
(GH-238) Monkey patch Facter for minimal resets

### DIFF
--- a/lib/puppet-languageserver-sidecar/facter_helper.rb
+++ b/lib/puppet-languageserver-sidecar/facter_helper.rb
@@ -21,6 +21,7 @@ module PuppetLanguageServerSidecar
       facts = PuppetLanguageServer::Sidecar::Protocol::FactList.new
       begin
         req = Puppet::Indirector::Request.new(:facts, :find, 'language_server', nil, environment: current_environment)
+        Facter.monkey_allow_reset # This is a monkey patched method onto Facter
         result = Puppet::Node::Facts::Facter.new.find(req)
         result.values.each do |key, value|
           # TODO: This isn't strictly correct e.g. fully qualified facts will look a bit odd.


### PR DESCRIPTION
Closes #238

It appears that Facter 4.0.16 is resetting the Facter search dirs
which then causes the sidecar to not find some external or custom facts.
This commit monkey patches the Facter module and makes it possible
to limit the number of resets to one.
