### PR TITLE
(GH-245) Use object cache for fact data

### DIFF
--- a/lib/puppet-languageserver/facter_helper.rb
+++ b/lib/puppet-languageserver/facter_helper.rb
@@ -46,5 +46,11 @@ module PuppetLanguageServer
       return [] if @facts_loaded == false
       cache.object_names_by_section(:fact).map(&:to_s)
     end
+
+    def self.facts_to_hash
+      fact_hash = {}
+      cache.objects_by_section(:fact) { |factname, fact| fact_hash[factname.to_s] = fact.value }
+      fact_hash
+    end
   end
 end

--- a/lib/puppet-languageserver/message_handler.rb
+++ b/lib/puppet-languageserver/message_handler.rb
@@ -46,7 +46,7 @@ module PuppetLanguageServer
     end
 
     def request_puppet_getfacts(_, _json_rpc_message)
-      results = PuppetLanguageServer::PuppetHelper.get_all_facts(documents.store_root_path)
+      results = PuppetLanguageServer::FacterHelper.facts_to_hash
       LSP::PuppetFactResponse.new('facts' => results)
     end
 

--- a/lib/puppet-languageserver/puppet_helper.rb
+++ b/lib/puppet-languageserver/puppet_helper.rb
@@ -54,15 +54,6 @@ module PuppetLanguageServer
       end
     end
 
-    def self.get_all_facts(local_workspace)
-      ap = PuppetLanguageServer::Sidecar::Protocol::ActionParams.new
-
-      args = ['--action-parameters=' + ap.to_json]
-      args << "--local-workspace=#{local_workspace}" unless local_workspace.nil?
-
-      sidecar_queue.execute_sync('facts_all', args, false)
-    end
-
     def self.get_puppet_resource(typename, title, local_workspace)
       ap = PuppetLanguageServer::Sidecar::Protocol::ActionParams.new
       ap['typename'] = typename

--- a/lib/puppet-languageserver/sidecar_queue.rb
+++ b/lib/puppet-languageserver/sidecar_queue.rb
@@ -118,16 +118,6 @@ module PuppetLanguageServer
 
         PuppetLanguageServer::FacterHelper.assert_facts_loaded
 
-      when 'facts_all'
-        list = {}
-        PuppetLanguageServer::Sidecar::Protocol::FactList
-          .new
-          .from_json!(result)
-          .map { |element| list[element.key] = element.value }
-        PuppetLanguageServer.log_message(:debug, "SidecarQueue Thread: facts returned #{list.count} items")
-
-        return list
-
       when 'node_graph'
         return PuppetLanguageServer::Sidecar::Protocol::PuppetNodeGraph.new.from_json!(result)
 

--- a/lib/puppet_languageserver_sidecar.rb
+++ b/lib/puppet_languageserver_sidecar.rb
@@ -119,7 +119,6 @@ module PuppetLanguageServerSidecar
     workspace_functions
     workspace_types
     facts
-    facts_all
   ].freeze
 
   class CommandLineParser
@@ -393,14 +392,6 @@ module PuppetLanguageServerSidecar
       end
 
     when 'facts'
-      # Can't cache for facts
-      cache = PuppetLanguageServerSidecar::Cache::Null.new
-      # Inject the workspace etc. if present
-      injected = inject_workspace_as_module
-      inject_workspace_as_environment unless injected
-      PuppetLanguageServerSidecar::FacterHelper.retrieve_facts(cache)
-
-    when 'facts_all'
       # Can't cache for facts
       cache = PuppetLanguageServerSidecar::Cache::Null.new
       # Inject the workspace etc. if present

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/facter_helper_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/facter_helper_spec.rb
@@ -51,23 +51,6 @@ describe 'PuppetLanguageServerSidecar::FacterHelper' do
     end
   end
 
-  describe 'when running facts_all action' do
-    let (:cmd_options) { ['--action', 'facts_all'] }
-
-    it 'should return a deserializable facts object with all default facts' do
-      result = run_sidecar(cmd_options)
-      deserial = PuppetLanguageServer::Sidecar::Protocol::FactList.new
-      expect { deserial.from_json!(result) }.to_not raise_error
-      default_fact_names.each do |name|
-        expect(deserial).to contain_child_with_key(name)
-      end
-
-      module_fact_names.each do |name|
-        expect(deserial).to_not contain_child_with_key(name)
-      end
-    end
-  end
-
   context 'given a workspace containing a module' do
     # Test fixtures used is fixtures/valid_module_workspace
     let(:workspace) { File.join($fixtures_dir, 'valid_module_workspace') }

--- a/spec/languageserver/spec_editor_client.rb
+++ b/spec/languageserver/spec_editor_client.rb
@@ -191,6 +191,15 @@ class EditorClient
     })
   end
 
+  def puppet_getfacts_request(seq_id)
+    ::JSON.generate({
+      'jsonrpc' => '2.0',
+      'id'      => seq_id,
+      'method'  => 'puppet/getFacts',
+      'params'  => {}
+    })
+  end
+
   def puppet_getresource_request(seq_id, type_name)
     ::JSON.generate({
       'jsonrpc' => '2.0',


### PR DESCRIPTION
Fixes #245 

This commit adds an acceptance test for the puppet/getFacts request. Previously
this message was added to the message handler, but not to the test suite.

---

Previously the puppet/getFacts request would call out to Facter directly however
this can be very slow, particularly with Facter v2 in the PDK.  This commit
changes the request to instead use the object cache which already has all of the
available facter information.

This commit also moves the method from the PuppetHelper to the FacterHelper
where it would make more sense.  This is tested as part of the acceptance suite.

---

Now that the language server no longer calls the facts_all action, the
supporting code can be removed.