### PR TITLE
(maint) Pin Rubocop to < 0.84.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
   gem 'rspec', '>= 3.2',            :require => false
 
   if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create('2.3.0')
-    gem "rubocop", ">= 0.80.0", :require => false, :platforms => [:ruby, :x64_mingw]
+    gem "rubocop", "~> 0.83.0", :require => false, :platforms => [:ruby, :x64_mingw]
   end
 
   if ENV['PUPPET_GEM_VERSION']


### PR DESCRIPTION
Due to https://github.com/rubocop-hq/rubocop/issues/8008 this commit pins
rubocop to 0.83.0 until the fix is release in 0.85.0.
