### PR TITLE
(GH-256) Add acceptance tests for puppetfile resolver request

### DIFF
--- a/spec/languageserver/spec_editor_client.rb
+++ b/spec/languageserver/spec_editor_client.rb
@@ -218,6 +218,15 @@ class EditorClient
     })
   end
 
+  def puppetfile_getdependencies_request(seq_id, uri)
+    ::JSON.generate({
+      'jsonrpc' => '2.0',
+      'id'      => seq_id,
+      'method'  => 'puppetfile/getDependencies',
+      'params'  => { 'uri' => uri }
+    })
+  end
+
   def completion_request(seq_id, uri, line, char, trigger_kind = LSP::CompletionTriggerKind::INVOKED, trigger_character = nil)
     hash = {
       'jsonrpc' => '2.0',


### PR DESCRIPTION
Previosuly in commit 77878f361bf a new puppetfile resolver endpoint was added.
However it was missing acceptance tests.  This commit adds a basic acceptance
smoke test for the puppetfile request.
