### PR TITLE
(maint) Document removal of Puppet 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@
 
 A ruby based implementation of a [Language Server](https://github.com/Microsoft/language-server-protocol) and [Debug Server](TODO) for the Puppet Language.
 
-**Note** - This project is experimental until 1.0 is released
+## Requirments
+
+* Puppet 5 or above
+
+* Ruby 2.4 or above
+
+**Note** that Puppet 4 (Ruby 2.1) is not supported
 
 ## Setting up editor services for development
 

--- a/Rakefile
+++ b/Rakefile
@@ -100,7 +100,7 @@ task :gem_revendor do
     sh "git clone #{vendor[:github_repo]} #{gem_dir}"
     Dir.chdir(gem_dir) do
       sh 'git fetch origin'
-      sh "git checkout #{vendor[:github_ref]}"
+      sh "git reset --hard #{vendor[:github_ref]}"
     end
 
     # Cleanup the gem directory...

--- a/lib/puppet-debugserver/puppet_debug_session.rb
+++ b/lib/puppet-debugserver/puppet_debug_session.rb
@@ -132,12 +132,6 @@ module PuppetDebugServer
       cmd_args << '--noop' if @session_options['noop'] == true
       cmd_args.push(*@session_options['args']) unless @session_options['args'].nil?
 
-      # Send experimental warning
-      send_output_event(
-        'category' => 'console',
-        'output'   => "**************************************************\n* The Puppet debugger is an experimental feature *\n* Debug Server v#{PuppetEditorServices.version}                           *\n**************************************************\n\n"
-      )
-
       send_output_event(
         'category' => 'console',
         'output'   => 'puppet ' + cmd_args.join(' ') + "\n"


### PR DESCRIPTION
This commit documents:

* Dropping Puppet 4 support

* Removing experimental warning for the debug server
