### PR TITLE
(GH-272) Puppet Lint and document symbol sometimes not working

### DIFF
--- a/lib/puppet-languageserver/manifest/document_symbol_provider.rb
+++ b/lib/puppet-languageserver/manifest/document_symbol_provider.rb
@@ -176,7 +176,7 @@ module PuppetLanguageServer
               'selectionRange' => create_range(param.offset, param.length, param.locator),
               'children'       => []
             )
-            this_symbol['children'].push(param_symbol)
+            this_symbol.children.push(param_symbol)
           end
 
         when 'Puppet::Pops::Model::AssignmentExpression'
@@ -209,7 +209,7 @@ module PuppetLanguageServer
               'selectionRange' => create_range(param.offset, param.length, param.locator),
               'children'       => []
             )
-            this_symbol['children'].push(param_symbol)
+            this_symbol.children.push(param_symbol)
           end
         end
 

--- a/lib/puppet-languageserver/manifest/validation_provider.rb
+++ b/lib/puppet-languageserver/manifest/validation_provider.rb
@@ -45,7 +45,12 @@ module PuppetLanguageServer
         if module_root.nil?
           linter_options = PuppetLint::OptParser.build
         else
-          Dir.chdir(module_root.to_s) { linter_options = PuppetLint::OptParser.build }
+          begin
+            Dir.chdir(module_root.to_s) { linter_options = PuppetLint::OptParser.build }
+          rescue OptionParser::InvalidOption => e
+            PuppetLanguageServer.log_message(:error, "(#{name}) Error reading Puppet Lint configuration.  Using default: #{e}")
+            linter_options = PuppetLint::OptParser.build
+          end
         end
         linter_options.parse!([])
 


### PR DESCRIPTION
Previously in commit fed22c2 the document symbol provider was updated
to use the new LSP classes however it appears some code branches were missed.

This commit updates the document symbol provider to use the correct method name.

---

Previously the Puppet-Lint configuration could raise an error, thereby stopping
any puppet lint rules from working.  This was due to puppet-lint.rc files
containing command params which were invalide due to puppet-lint plugin gems
not being loaded e.g. --no-trailing_comma-check

This commit changes the document validator to use the default configuration if
an error occurs loading the configuration.