### PR TITLE
(GH-282) Add Puppet 7 to CI testing 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ env:
     - PUPPET_GEM_VERSION="~> 6.0"
       RUBY_VER=2.5.1
       RAKE_TASK="gem_revendor test_languageserver test_languageserver_sidecar test_debugserver"
+    # Latest 7.x Puppet
+    - PUPPET_GEM_VERSION="~> 7.0"
+      RUBY_VER=2.7.2
+      RAKE_TASK="gem_revendor test_languageserver test_languageserver_sidecar test_debugserver"
 
     # Specific Puppet version testing
     - PUPPET_GEM_VERSION="5.1.0"
@@ -34,8 +38,8 @@ env:
       RAKE_TASK="gem_revendor test_languageserver"
 
     # Acceptance tests.
-    - PUPPET_GEM_VERSION="~> 6.0"
-      RUBY_VER=2.5.1
+    - PUPPET_GEM_VERSION="~> 7.0"
+      RUBY_VER=2.7.2
       RAKE_TASK="gem_revendor acceptance_languageserver"
 
     # Ruby tasks (style).  Puppet version is irrelevant

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ install:
 - ps: |
      if ($ENV:APPVEYOR_PULL_REQUEST_NUMBER -ne $null) {
        Write-Host "Setting build version..."
-       $ENV:APPVEYOR_BUILD_VERSION | Out-File -FilePath 'lib\puppet-editor-services\VERSION' -Encoding ASCII -Confirm:$false -Force
+       $ENV:APPVEYOR_BUILD_VERSION | Out-File -FilePath 'lib\puppet_editor_services\VERSION' -Encoding ASCII -Confirm:$false -Force
      }
 
      if ($ENV:RUBY_VER -ne $null) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ version: 99.99.0-appv.{build}
 clone_depth: 10
 init:
 - SET
+image:
+  - Visual Studio 2019
 
 environment:
   matrix:
@@ -15,17 +17,22 @@ environment:
     RUBY_VER: 25-x64
     RAKE_TASK: "gem_revendor test_languageserver test_languageserver_sidecar test_debugserver"
 
-    # Specific Puppet version testing
+  # Latest 7.x Puppet
+  - PUPPET_GEM_VERSION: "~> 7.0"
+    RUBY_VER: 27-x64
+    RAKE_TASK: "gem_revendor test_languageserver test_languageserver_sidecar test_debugserver"
+
+  # Specific Puppet version testing
   - PUPPET_GEM_VERSION: "5.1.0"
     RUBY_VER: 24-x64
     RAKE_TASK: "gem_revendor test_languageserver"
 
-    # Acceptance tests.
-  - PUPPET_GEM_VERSION: "~> 6.0"
-    RUBY_VER: 25-x64
+  # Acceptance tests
+  - PUPPET_GEM_VERSION: "~> 7.0"
+    RUBY_VER: 27-x64
     RAKE_TASK: "gem_revendor acceptance_languageserver"
 
-    # Ruby tasks (style, build release archives)
+  # Ruby tasks (style, build release archives)
   - PUPPET_GEM_VERSION: "> 0.0" # Version is irrelevant
     RUBY_VER: 25-x64
     RAKE_TASK: rubocop build

--- a/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb
@@ -230,16 +230,19 @@ module PuppetLanguageServerSidecar
 
           sig.key = signature[:signature]
           sig.doc = signature[:docstring][:text]
-          signature[:docstring][:tags].each do |tag|
-            case tag[:tag_name]
-            when 'param'
-              sig.parameters << PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionSignatureParameter.new.from_h!(
-                'name'  => tag[:name],
-                'types' => tag[:types],
-                'doc'   => tag[:text]
-              )
-            when 'return'
-              sig.return_types = tag[:types]
+
+          unless signature[:docstring][:tags].nil?
+            signature[:docstring][:tags].each do |tag|
+              case tag[:tag_name]
+              when 'param'
+                sig.parameters << PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionSignatureParameter.new.from_h!(
+                  'name'  => tag[:name],
+                  'types' => tag[:types],
+                  'doc'   => tag[:text]
+                )
+              when 'return'
+                sig.return_types = tag[:types]
+              end
             end
           end
           calculate_signature_parameter_locations!(sig)

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet-languageserver-sidecar_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet-languageserver-sidecar_spec.rb
@@ -13,9 +13,9 @@ describe 'PuppetLanguageServerSidecar', :if => Gem::Version.new(Puppet.version) 
 
     cmd.unshift('puppet-languageserver-sidecar')
     cmd.unshift('ruby')
-    stdout, _stderr, status = Open3.capture3(*cmd)
+    stdout, stderr, status = Open3.capture3(*cmd)
 
-    raise "Expected exit code of 0, but got #{status.exitstatus} #{_stderr}" unless status.exitstatus.zero?
+    raise "Expected exit code of 0, but got #{status.exitstatus} #{stderr}" unless status.exitstatus.zero?
     return stdout.bytes.pack('U*')
   end
 


### PR DESCRIPTION
Fixes #282 

When querying with Puppet7/Ruby 2.7 it's possibe for yard to return a docstring
with no tags at all.  Previously this was an empty array but now it may also be
nil.  This commit adds a guard to only enumerate the array if it is not nil.

This commit adds Puppet 7 to the test CI matrix now that it has been released.