### PR TITLE
(GH-189) Reset PuppetLint configuration for each call

### DIFF
--- a/spec/languageserver/integration/puppet-languageserver/manifest/validation_provider_spec.rb
+++ b/spec/languageserver/integration/puppet-languageserver/manifest/validation_provider_spec.rb
@@ -194,5 +194,20 @@ describe 'PuppetLanguageServer::Manifest::ValidationProvider' do
         end
       end
     end
+
+    describe "Given a complete manifest with validation errors" do
+      let(:manifest) { "class bad_formatting {\n  user { 'username':\n    ensure => absent,\n    auth_membership => 'false',\n  }\n} " }
+
+      it "should return errors and warnings even after fix_validate_errors" do
+        fixes = subject.fix_validate_errors(session_state, manifest)
+        validation = subject.validate(session_state, manifest)
+
+        expect(validation.count).to_not be_zero
+
+        validation.each do |problem|
+          expect([LSP::DiagnosticSeverity::ERROR, LSP::DiagnosticSeverity::WARNING]).to include(problem.severity)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #189 

Previously after a call to fix_validation_errors, many validation errors came
in as hints not errors.  This was due to PuppetLint not resetting the
`PuppetLint.configuration.fix` setting between calls.  This commit updates the
validation provider to reset this setting each call.  This commit also adds
tests for this scenario.
