### PR TITLE
(GH-289) Make Format On Type file size configurable

### DIFF
--- a/lib/puppet-languageserver/manifest/format_on_type_provider.rb
+++ b/lib/puppet-languageserver/manifest/format_on_type_provider.rb
@@ -11,14 +11,16 @@ module PuppetLanguageServer
         end
       end
 
-      def format(content, line, char, trigger_character, formatting_options)
+      def format(content, line, char, trigger_character, formatting_options, max_filesize = 4096)
         result = []
         # Abort if the user has pressed something other than `>`
         return result unless trigger_character == '>'
         # Abort if the formatting is tab based. Can't do that yet
         return result unless formatting_options['insertSpaces'] == true
         # Abort if content is too big
-        return result if content.length > 4096
+        unless max_filesize.zero?
+          return result if content.length > max_filesize
+        end
 
         lexer = PuppetLint::Lexer.new
         tokens = lexer.tokenise(content)

--- a/lib/puppet-languageserver/message_handler.rb
+++ b/lib/puppet-languageserver/message_handler.rb
@@ -232,7 +232,8 @@ module PuppetLanguageServer
           line_num,
           char_num,
           json_rpc_message.params['ch'],
-          json_rpc_message.params['options']
+          json_rpc_message.params['options'],
+          language_client.format_on_type_filesize_limit
         )
       else
         raise "Unable to format on type on #{file_uri}"

--- a/spec/languageserver/unit/puppet-languageserver/message_handler_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/message_handler_spec.rb
@@ -805,7 +805,7 @@ describe 'PuppetLanguageServer::MessageHandler' do
 
           it 'should call format method on the Format On Type provider' do
             expect(provider).to receive(:format)
-              .with(file_content, line_num, char_num, trigger_char, formatting_options).and_return('something')
+              .with(file_content, line_num, char_num, trigger_char, formatting_options, Integer).and_return('something')
             subject.request_textdocument_ontypeformatting(connection_id, request_message)
           end
 


### PR DESCRIPTION
Fixes #289 

Previously only files that were less than 4KB in size could use the
format-on-type feature. This commit updates the Language Server to honor a
new configuration setting puppet.editorService.formatOnType.maxFileSize which
will determine the maximum file size.  A size of 0 will disable the size check.
The default is 4096 as per the previous behaviour.

No specific tests have been added and has been manually tested.

