### PR TITLE
(GH-189) Fix module root for validation

### DIFF
--- a/lib/puppet-languageserver/manifest/validation_provider.rb
+++ b/lib/puppet-languageserver/manifest/validation_provider.rb
@@ -116,7 +116,7 @@ module PuppetLanguageServer
           linter_options = PuppetLint::OptParser.build
         else
           begin
-            Dir.chdir(module_root.to_s) { linter_options = PuppetLint::OptParser.build }
+            Dir.chdir(root_dir.to_s) { linter_options = PuppetLint::OptParser.build }
           rescue OptionParser::InvalidOption => e
             PuppetLanguageServer.log_message(:error, "(#{name}) Error reading Puppet Lint configuration.  Using default: #{e}")
             linter_options = PuppetLint::OptParser.build


### PR DESCRIPTION
Previously in commit c70511b9 validation was changed to initialise Puppet Lint
correctly, however there was a typo in the provider.  This commit fixes the
typo and references the correct variable.
