### PR TITLE
(GH-298) Fix tests for Facter 4.0.52 gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/ak9eht4vqavnmjf9?svg=true)](https://ci.appveyor.com/project/puppetlabs/puppet-editor-services)
-[![Build Status](https://travis-ci.com/puppetlabs/puppet-editor-services.svg?branch=master)](https://travis-ci.com/puppetlabs/puppet-editor-services)
+[![Editor Services CI](https://github.com/puppetlabs/puppet-editor-services/actions/workflows/editor-services-ci.yml/badge.svg)](https://github.com/puppetlabs/puppet-editor-services/actions/workflows/editor-services-ci.yml)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/puppetlabs/puppet-editor-services)
 
 # Puppet Editor Services

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/facter_helper_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/facter_helper_spec.rb
@@ -30,7 +30,7 @@ describe 'PuppetLanguageServerSidecar::FacterHelper', :if => Gem::Version.new(Pu
     end
   end
 
-  let(:default_fact_names) { %i[hostname fixture_agent_custom_fact] }
+  let(:default_fact_names) { %i[facterversion fixture_agent_custom_fact] }
   let(:module_fact_names) { %i[fixture_module_custom_fact fixture_module_external_fact] }
   let(:environment_fact_names) { %i[fixture_environment_custom_fact fixture_environment_external_fact] }
 


### PR DESCRIPTION
Fixes #298 

The facter 4.0.52 gem uses FFI to retrieve the legacy hostname fact. However as
FFI wasn't available it was breaking the integration tests. This commit changes
the expected fact name, from a legacy fact to a modern fact which should not
ever be removed (facterversion).