### PR TITLE
(GH-300) Return nil for bad hover requests

### DIFF
--- a/lib/puppet-languageserver/manifest/hover_provider.rb
+++ b/lib/puppet-languageserver/manifest/hover_provider.rb
@@ -10,7 +10,7 @@ module PuppetLanguageServer
         result = PuppetLanguageServer::PuppetParserHelper.object_under_cursor(content, line_num, char_num,
                                                                               :disallowed_classes => [Puppet::Pops::Model::BlockExpression],
                                                                               :tasks_mode         => options[:tasks_mode])
-        return LSP::Hover.new if result.nil?
+        return nil if result.nil?
 
         path = result[:path]
         item = result[:model]
@@ -78,6 +78,7 @@ module PuppetLanguageServer
           raise "Unable to generate Hover information for object of type #{item.class}"
         end
 
+        return nil if content.nil?
         LSP::Hover.new('contents' => content)
       end
 

--- a/lib/puppet-languageserver/message_handler.rb
+++ b/lib/puppet-languageserver/message_handler.rb
@@ -183,7 +183,7 @@ module PuppetLanguageServer
       end
     rescue StandardError => e
       PuppetLanguageServer.log_message(:error, "(textDocument/hover) #{e}")
-      LSP::Hover.new
+      nil
     end
 
     def request_textdocument_definition(_, json_rpc_message)

--- a/spec/languageserver/integration/puppet-languageserver/manifest/hover_provider_spec.rb
+++ b/spec/languageserver/integration/puppet-languageserver/manifest/hover_provider_spec.rb
@@ -110,7 +110,7 @@ EOT
       it 'should return nil' do
         result = subject.resolve(session_state, content, line_num, char_num)
 
-        expect(result.contents).to eq(nil)
+        expect(result).to be_nil
       end
     end
 

--- a/spec/languageserver/unit/puppet-languageserver/message_handler_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/message_handler_spec.rb
@@ -589,8 +589,8 @@ describe 'PuppetLanguageServer::MessageHandler' do
           subject.request_textdocument_hover(connection_id, request_message)
         end
 
-        it 'should reply with nil for the contents' do
-          expect(subject.request_textdocument_hover(connection_id, request_message)).to have_attributes(:contents => nil)
+        it 'should reply with nil' do
+          expect(subject.request_textdocument_hover(connection_id, request_message)).to be_nil
         end
       end
 
@@ -618,8 +618,8 @@ describe 'PuppetLanguageServer::MessageHandler' do
             subject.request_textdocument_hover(connection_id, request_message)
           end
 
-          it 'should reply with nil for the contents' do
-            expect(subject.request_textdocument_hover(connection_id, request_message)).to have_attributes(:contents => nil)
+          it 'should reply with nil' do
+            expect(subject.request_textdocument_hover(connection_id, request_message)).to be_nil
           end
         end
       end


### PR DESCRIPTION
Fixes #300 

Previously, the hover provider would return a Hover object with null contents
which is not allowed by the Language Server Protocol.  This commit updates
Editor Services to instead return nil when an error occurs during the resolution.
