### PR TITLE
(GH-306) Add a syntax aware code folding provider

### DIFF
--- a/lib/puppet-languageserver/manifest/folding_provider.rb
+++ b/lib/puppet-languageserver/manifest/folding_provider.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require 'puppet-languageserver/puppet_lexer_helper'
+require 'lsp/lsp'
+
+module PuppetLanguageServer
+  module Manifest
+    class FoldingProvider
+      class << self
+        def instance
+          @instance ||= new
+        end
+
+        def supported?
+          # Folding is only supported on Puppet 6.3.0 and above
+          # Requires - https://github.com/puppetlabs/puppet/commit/6d375ab4d735779031d49ab8631bd9d161a9c3e3
+          @supported ||= Gem::Version.new(Puppet.version) >= Gem::Version.new('6.3.0')
+        end
+      end
+
+      REGION_NONE = nil
+      REGION_COMMENT = 'comment'
+      REGION_REGION = 'region'
+
+      def start_region?(text)
+        !(text =~ %r{^#\s*region\b}).nil?
+      end
+
+      def end_region?(text)
+        !(text =~ %r{^#\s*endregion\b}).nil?
+      end
+
+      def folding_ranges(tokens, show_last_line = false)
+        return nil unless self.class.supported?
+        ranges = {}
+
+        brace_stack = []
+        brack_stack = []
+        comment_stack = []
+
+        index = 0
+        until index > tokens.length - 1
+          case tokens[index][0]
+          # Find comments
+          when :TOKEN_COMMENT
+            if block_comment?(index, tokens)
+              comment = tokens[index][1].locator.extract_text(tokens[index][1].offset, tokens[index][1].length)
+              if start_region?(comment) # rubocop:disable Metrics/BlockNesting
+                comment_stack.push(tokens[index][1])
+              elsif end_region?(comment) && !comment_stack.empty? # rubocop:disable Metrics/BlockNesting
+                add_range!(create_range_span_tokens(comment_stack.pop, tokens[index][1], REGION_REGION), ranges)
+              else
+                index = process_block_comment!(index, tokens, ranges)
+              end
+            end
+
+          # Find old style comments /* -> */
+          when :TOKEN_MLCOMMENT
+            add_range!(create_range_whole_token(tokens[index][1], REGION_COMMENT), ranges)
+
+          # Find matching braces { -> } and select brace ?{ -> }
+          when :LBRACE, :SELBRACE
+            brace_stack.push(tokens[index][1])
+          when :RBRACE
+            add_range!(create_range_span_tokens(brace_stack.pop, tokens[index][1], REGION_NONE), ranges) unless brace_stack.empty?
+
+          # Find matching braces [ -> ], list and index
+          when :LISTSTART, :LBRACK
+            brack_stack.push(tokens[index][1])
+          when :RBRACK
+            add_range!(create_range_span_tokens(brack_stack.pop, tokens[index][1], REGION_NONE), ranges) unless brack_stack.empty?
+
+          # Find matching Heredoc and heredoc sublocations
+          when :HEREDOC
+            # Need to check if the next token is :SUBLOCATE
+            if index < tokens.length - 2 && tokens[index + 1][0] == :SUBLOCATE # rubocop:disable Style/IfUnlessModifier
+              add_range!(create_range_heredoc(tokens[index][1], tokens[index + 1][1], REGION_NONE), ranges)
+            end
+          end
+
+          index += 1
+        end
+
+        # If we are showing the last line then decrement the EndLine by one, if possible
+        if show_last_line
+          ranges.values.each do |range|
+            range.endLine = [range.startLine, range.endLine - 1].max
+            range.endCharacter = 0 # We don't know where the previous line actually ends so set it to zero
+          end
+        end
+
+        ranges.values
+      end
+
+      private
+
+      # region Internal Helper methods to call locator methods on Locators or SubLocators
+      def line_for_offset(token, offset = nil)
+        locator_method_with_offset(token, :line_for_offset, offset || token.offset)
+      end
+
+      def pos_on_line(token, offset = nil)
+        locator_method_with_offset(token, :pos_on_line, offset || token.offset)
+      end
+
+      def locator_method_with_offset(token, method_name, offset)
+        if token.locator.is_a?(Puppet::Pops::Parser::Locator::SubLocator)
+          global_offset, = token.locator.to_global(offset, token.length)
+          token.locator.locator.send(method_name, global_offset)
+        else
+          token.locator.send(method_name, offset)
+        end
+      end
+
+      def extract_text(token)
+        if token.locator.is_a?(Puppet::Pops::Parser::Locator::SubLocator)
+          global_offset, global_length = token.locator.to_global(token.offset, token.length)
+          token.locator.locator.extract_text(global_offset, global_length)
+        else
+          token.locator.extract_text(token.offset, token.length)
+        end
+      end
+      # endregion
+
+      # Return nil if not valid range
+      def create_range_span_tokens(start_token, end_token, kind)
+        start_line = line_for_offset(start_token) - 1
+        end_line = line_for_offset(end_token) - 1
+        return nil if start_line == end_line
+        LSP::FoldingRange.new({
+                                'startLine'      => start_line,
+                                'startCharacter' => pos_on_line(start_token) - 1,
+                                'endLine'        => end_line,
+                                'endCharacter'   => pos_on_line(end_token, end_token.offset + end_token.length) - 1,
+                                'kind'           => kind
+                              })
+      end
+
+      # Return nil if not valid range
+      def create_range_whole_token(token, kind)
+        start_line = line_for_offset(token) - 1
+        end_line = line_for_offset(token, token.offset + token.length) - 1
+        return nil if start_line == end_line
+        LSP::FoldingRange.new({
+                                'startLine'      => start_line,
+                                'startCharacter' => pos_on_line(token) - 1,
+                                'endLine'        => end_line,
+                                'endCharacter'   => pos_on_line(token, token.offset + token.length) - 1,
+                                'kind'           => kind
+                              })
+      end
+
+      # Return nil if not valid range
+      def create_range_heredoc(heredoc_token, subloc_token, kind)
+        start_line = line_for_offset(heredoc_token) - 1
+        # The lexer does not output the end heredoc_token. Instead we
+        # use the heredoc sublocator endline and add one
+        end_line = line_for_offset(heredoc_token, heredoc_token.offset + heredoc_token.length + subloc_token.length)
+        return nil if start_line == end_line
+        LSP::FoldingRange.new({
+                                'startLine'      => start_line,
+                                'startCharacter' => pos_on_line(heredoc_token) - 1,
+                                'endLine'        => end_line,
+                                # We don't know where the end token for the Heredoc is, so just assume it's at the start of the line
+                                'endCharacter'   => 0,
+                                'kind'           => kind
+                              })
+      end
+
+      # Adds a FoldingReference to the list and enforces ordering rules e.g. Only one fold per start line
+      def add_range!(range, ranges)
+        # Make sure the arguments are correct
+        return nil if range.nil? || ranges.nil?
+
+        # Ignore the range if there is an existing one which is bigger
+        return nil unless ranges[range.startLine].nil? || ranges[range.startLine].endLine < range.endLine
+        ranges[range.startLine] = range
+        nil
+      end
+
+      # Returns new index position
+      def process_block_comment!(index, tokens, ranges)
+        start_index = index
+        line_num = line_for_offset(tokens[index][1])
+        while index < tokens.length - 2
+          break unless tokens[index + 1][0] == :TOKEN_COMMENT
+          next_line = line_for_offset(tokens[index + 1][1])
+          # Tokens must be on contiguous lines
+          break unless next_line == line_num + 1
+          # Must not be a region comment
+          comment = extract_text(tokens[index + 1][1])
+          break if start_region?(comment) || end_region?(comment)
+          # It's a block comment
+          line_num = next_line
+          index += 1
+        end
+
+        return index if start_index == index
+
+        add_range!(create_range_span_tokens(tokens[start_index][1], tokens[index][1], REGION_COMMENT), ranges)
+        index
+      end
+
+      def block_comment?(index, tokens)
+        # Has to be a comment token
+        return false unless tokens[index][0] == :TOKEN_COMMENT
+        # If it's the first token then it has to be at the start of a line
+        return true if index.zero?
+        # It has to be the first token on this line
+        this_token_line = line_for_offset(tokens[index][1])
+        prev_token_line = line_for_offset(tokens[index - 1][1])
+
+        this_token_line != prev_token_line
+      end
+    end
+  end
+end

--- a/lib/puppet-languageserver/providers.rb
+++ b/lib/puppet-languageserver/providers.rb
@@ -5,6 +5,7 @@
   manifest/completion_provider
   manifest/definition_provider
   manifest/document_symbol_provider
+  manifest/folding_provider
   manifest/format_on_type_provider
   manifest/signature_provider
   manifest/validation_provider

--- a/lib/puppet-languageserver/puppet_lexer_helper.rb
+++ b/lib/puppet-languageserver/puppet_lexer_helper.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Puppet
+  module Pops
+    module Parser
+      # This Lexer adds code to create comment tokens.
+      # The default lexer just throws them out
+      # Ref - https://github.com/puppetlabs/puppet-specifications/blob/master/language/lexical_structure.md#comments
+      class Lexer2WithComments < Puppet::Pops::Parser::Lexer2
+        # The PATTERN_COMMENT in lexer2 also consumes the trailing \r in the token and
+        # we don't want that.
+        PATTERN_COMMENT_NO_WS = %r{#[^\r\n]*}.freeze
+
+        TOKEN_COMMENT = [:COMMENT, '#', 1].freeze
+        TOKEN_MLCOMMENT = [:MLCOMMENT, nil, 0].freeze
+
+        def initialize
+          super
+
+          # Remove the selector for line comments so we can add our own
+          @new_selector = @selector.reject { |k, _v| k == '#' }
+
+          # Add code to scan line comments
+          @new_selector['#'] = lambda {
+            scn = @scanner
+            before = scn.pos
+            value = scn.scan(PATTERN_COMMENT_NO_WS)
+
+            if value
+              emit_completed([:TOKEN_COMMENT, value[1..-1].freeze, scn.pos - before], before)
+            else
+              # It's probably not possible to EVER get here ... but just incase
+              emit(TOKEN_COMMENT, before)
+            end
+          }.freeze
+
+          # Add code to scan multi-line comments
+          old_lambda = @new_selector['/']
+          @new_selector['/'] = lambda {
+            scn = @scanner
+            la = scn.peek(2)
+            if la[1] == '*'
+              before = scn.pos
+              value = scn.scan(PATTERN_MLCOMMENT)
+              return emit_completed([:TOKEN_MLCOMMENT, value[2..-3].freeze, scn.pos - before], before) if value
+            end
+            old_lambda.call
+          }.freeze
+          @new_selector.freeze
+          @selector = @new_selector
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet-languageserver/server_capabilities.rb
+++ b/lib/puppet-languageserver/server_capabilities.rb
@@ -4,6 +4,10 @@ require 'lsp/lsp'
 
 module PuppetLanguageServer
   module ServerCapabilites
+    def self.folding_provider_supported?
+      @folding_provider ||= PuppetLanguageServer::Manifest::FoldingProvider.supported?
+    end
+
     def self.capabilities(options = {})
       # https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#initialize-request
 
@@ -22,6 +26,7 @@ module PuppetLanguageServer
         }
       }
       value['documentOnTypeFormattingProvider'] = document_on_type_formatting_options if options[:documentOnTypeFormattingProvider]
+      value['foldingRangeProvider'] = folding_range_provider_options if options[:foldingRangeProvider]
       value
     end
 
@@ -29,6 +34,10 @@ module PuppetLanguageServer
       {
         'firstTriggerCharacter' => '>'
       }
+    end
+
+    def self.folding_range_provider_options
+      true
     end
 
     def self.no_capabilities

--- a/lib/puppet_languageserver.rb
+++ b/lib/puppet_languageserver.rb
@@ -81,6 +81,7 @@ module PuppetLanguageServer
     %w[
       sidecar_protocol
       global_queues
+      puppet_lexer_helper
       puppet_parser_helper
       puppet_helper
       facter_helper

--- a/spec/languageserver/unit/puppet-languageserver/manifest/folding_provider_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/manifest/folding_provider_spec.rb
@@ -1,0 +1,374 @@
+require 'spec_helper'
+
+RSpec::Matchers.define :be_folding_range do |expected|
+  match do |actual|
+    expected.startLine == actual.startLine &&
+    expected.startCharacter == actual.startCharacter &&
+    expected.endLine == actual.endLine &&
+    expected.endCharacter == actual.endCharacter &&
+    expected.kind == actual.kind
+  end
+
+  failure_message do |actual|
+    "expected that foldable range (#{actual.startLine}, #{actual.startCharacter}, #{actual.endLine}, #{actual.endCharacter}, #{actual.kind})" +
+    " would be (#{expected.startLine}, #{expected.startCharacter}, #{expected.endLine}, #{expected.endCharacter}, #{expected.kind})"
+  end
+
+  description do
+    "be a foldable range of (#{expected.startLine}, #{expected.startCharacter}, #{expected.endLine}, #{expected.endCharacter}, #{expected.kind})"
+  end
+end
+
+def compare_range(this, that)
+  # Initially look at the start line
+  return -1 if this.startLine < that.startLine
+  return 1 if this.startLine > that.startLine
+
+  # They have the same start line so now consider the end line.
+  # The biggest line range is sorted first
+  return -1 if this.endLine > that.endLine
+  return 1 if this.endLine < that.endLine
+
+  # They have the same lines, but what about character offsets
+  return -1 if this.startCharacter < that.startCharacter
+  return 1 if this.startCharacter > that.startCharacter
+  return -1 if this.endCharacter < that.endCharacter
+  return 1 if this.endCharacter > that.endCharacter
+
+  # They're the same range, but what about kind
+  this.kind.to_s <=> that.kind.to_s
+end
+
+def lsp_range(item)
+  LSP::FoldingRange.new({
+    'startLine'      => item[0],
+    'startCharacter' => item[1],
+    'endLine'        => item[2],
+    'endCharacter'   => item[3],
+    'kind'           => item[4],
+  })
+end
+
+describe 'PuppetLanguageServer::Manifest::FoldingProvider' do
+  describe '::instance' do
+    it 'should exist' do
+      expect(PuppetLanguageServer::Manifest::FoldingProvider).to respond_to(:instance)
+    end
+
+    it 'should return the same object' do
+      object1 = PuppetLanguageServer::Manifest::FoldingProvider.instance
+      object2 = PuppetLanguageServer::Manifest::FoldingProvider.instance
+      expect(object1).to eq(object2)
+    end
+  end
+
+  describe '#folding_ranges', :unless => PuppetLanguageServer::Manifest::FoldingProvider.supported? do
+    context 'when folding is not supported' do
+      it 'returns nil' do
+        subject = PuppetLanguageServer::Manifest::FoldingProvider.new
+        expect(subject.folding_ranges([])).to be_nil
+      end
+    end
+  end
+
+  describe '#folding_ranges', :if => PuppetLanguageServer::Manifest::FoldingProvider.supported? do
+    def expect_ranges(actual, expected)
+      expect(actual.count).to eq(expected.count)
+
+      # Sort the array to make it easier to assert equality
+      actual.sort! { |this, that| compare_range(this, that) }
+
+      actual.each_with_index do |actual_range, index|
+        expect(actual_range).to be_folding_range(expected[index])
+      end
+    end
+
+    context 'with all types of folding' do
+      let(:doc_uri) { 'file://fakeuri.pp' }
+      let(:doc_version) { 1 }
+      let(:doc_store) do
+        doc_store = PuppetLanguageServer::SessionState::DocumentStore.new
+        doc_store.set_document(doc_uri, content, doc_version)
+        doc_store
+      end
+
+      let(:content) do
+<<-HEREDOC
+# this won't be folded
+
+# This block of comments should be foldable as a single block
+# This block of comments should be foldable as a single block
+# This block of comments should be foldable as a single block
+
+#region This should fold
+/*
+Nested different comment types.  This should fold
+*/
+#endregion
+
+# Comment Block 1
+# Comment Block 1
+# Comment Block 1
+# region Comment Block 3
+# Comment Block 2
+# Comment Block 2
+# Comment Block 2
+# endregion Comment Block 3
+
+class foldable {
+  fail('boo')
+}
+
+class notfoldable {}
+
+$non_folding_hash = { a => 3, b => 4 }
+
+$folding_hash = {
+  a => 3,
+  b => 4,
+}
+
+$folding_array = [
+  'abc',
+  '123'
+]
+
+  file { 'C:\\something': # The line span fools the indentation based folding
+    ensure => present,
+    content => "Line
+Span"
+  }
+
+#Region This should not fold due to casing on (R)egion
+file { 'something': }
+#Endregion
+
+HEREDOC
+      end
+
+      let(:expected_ranges) do
+        [
+          lsp_range([2,  0,   4, 61,  'comment']),
+          lsp_range([6,  0,  10, 10,  'region']),
+          lsp_range([7,  0,   9,  2,  'comment']),
+          lsp_range([12, 0,  14, 17,  'comment']),
+          lsp_range([15, 0,  19, 27,  'region']),
+          lsp_range([16, 0,  18, 17,  'comment']),
+          lsp_range([21, 15, 23,  1,  nil]),
+          lsp_range([29, 16, 32,  1,  nil]),
+          lsp_range([34, 17, 37,  1,  nil]),
+          lsp_range([39, 7,  43,  3,  nil])
+        ]
+      end
+
+      it 'returns expected regions for LF endings' do
+        subject = PuppetLanguageServer::Manifest::FoldingProvider.new
+        expect(content).not_to include("\r\n")
+        actual_ranges = subject.folding_ranges(doc_store.document_tokens(doc_uri, doc_version))
+        expect_ranges(actual_ranges, expected_ranges)
+      end
+
+      it 'returns expected regions for CRLF endings' do
+        subject = PuppetLanguageServer::Manifest::FoldingProvider.new
+        content.gsub!("\n", "\r\n")
+        actual_ranges = subject.folding_ranges(doc_store.document_tokens(doc_uri, doc_version))
+        expect_ranges(actual_ranges, expected_ranges)
+      end
+
+      it 'returns expected regions when the Last Line is shown' do
+        subject = PuppetLanguageServer::Manifest::FoldingProvider.new
+
+        # When the last line is show it should reduce the end line by one and reset the end character to zero
+        expected_ranges.each do |range|
+          range.endLine = range.endLine - 1
+          range.endCharacter = 0
+        end
+
+        actual_ranges = subject.folding_ranges(doc_store.document_tokens(doc_uri, doc_version), true)
+        expect_ranges(actual_ranges, expected_ranges)
+      end
+    end
+
+    context 'with mismatched regions' do
+      let(:doc_uri) { 'file://fakeuri.pp' }
+      let(:doc_version) { 1 }
+      let(:doc_store) do
+        doc_store = PuppetLanguageServer::SessionState::DocumentStore.new
+        doc_store.set_document(doc_uri, content, doc_version)
+        doc_store
+      end
+
+      let(:content) do
+<<-HEREDOC
+#endregion should not fold - mismatched
+
+#region This should fold
+$something = 'foldable'
+#endregion
+
+#region should not fold - mismatched
+HEREDOC
+      end
+
+      let(:expected_ranges) do
+        [
+          lsp_range([2, 0, 4, 10, 'region']),
+        ]
+      end
+
+      it 'returns only matched regions' do
+        subject = PuppetLanguageServer::Manifest::FoldingProvider.new
+        expect(content).not_to include("\r\n")
+        actual_ranges = subject.folding_ranges(doc_store.document_tokens(doc_uri, doc_version))
+        expect_ranges(actual_ranges, expected_ranges)
+      end
+    end
+
+    context 'with duplicate regions on the same line' do
+      let(:doc_uri) { 'file://fakeuri.pp' }
+      let(:doc_version) { 1 }
+      let(:doc_store) do
+        doc_store = PuppetLanguageServer::SessionState::DocumentStore.new
+        doc_store.set_document(doc_uri, content, doc_version)
+        doc_store
+      end
+
+      let(:content) do
+<<-HEREDOC
+# This script causes duplicate/overlapping ranges due to the `[` and `{` characters
+$var = [{
+  'abc' => 123},{ 'xyz' => 234
+  # Do Something
+}]
+HEREDOC
+      end
+
+      let(:expected_ranges) do
+        [
+          lsp_range([1, 7, 4, 2, nil]),
+          lsp_range([2, 16, 4, 1, nil]),
+        ]
+      end
+
+      it 'returns only matched regions' do
+        subject = PuppetLanguageServer::Manifest::FoldingProvider.new
+        expect(content).not_to include("\r\n")
+        actual_ranges = subject.folding_ranges(doc_store.document_tokens(doc_uri, doc_version))
+        expect_ranges(actual_ranges, expected_ranges)
+      end
+    end
+
+    context 'with regions with the similar tokens' do
+      let(:doc_uri) { 'file://fakeuri.pp' }
+      let(:doc_version) { 1 }
+      let(:doc_store) do
+        doc_store = PuppetLanguageServer::SessionState::DocumentStore.new
+        doc_store.set_document(doc_uri, content, doc_version)
+        doc_store
+      end
+
+      # This tests that token matching { -> }, ?{ -> } and
+      # [ -> ], @arr[ -> ]does not confuse the folder
+      let(:content) do
+<<-HEREDOC
+class myclass($x = 10, $y = 20) {
+  $ret = select ? {
+    /abc/   => 123,
+    default => 456
+  }
+}
+
+$arr2 = [
+  $arr1[
+    0
+  ]
+]
+HEREDOC
+      end
+
+      let(:expected_ranges) do
+        [
+          lsp_range([0, 32, 5, 1, nil]),
+          lsp_range([1, 18, 4, 3, nil]),
+          lsp_range([7, 8, 11, 1, nil]),
+          lsp_range([8, 7, 10, 3, nil])
+        ]
+      end
+
+      it 'returns only matched regions' do
+        subject = PuppetLanguageServer::Manifest::FoldingProvider.new
+        expect(content).not_to include("\r\n")
+        actual_ranges = subject.folding_ranges(doc_store.document_tokens(doc_uri, doc_version))
+        expect_ranges(actual_ranges, expected_ranges)
+      end
+    end
+
+    context 'with regions inside different heredoc strings' do
+      let(:doc_uri) { 'file://fakeuri.pp' }
+      let(:doc_version) { 1 }
+      let(:doc_store) do
+        doc_store = PuppetLanguageServer::SessionState::DocumentStore.new
+        doc_store.set_document(doc_uri, content, doc_version)
+        doc_store
+      end
+
+      let(:content) do
+<<-HEREDOC
+$heredoc1 = @("SHORT"/L)
+    [user]
+      name = ${displayname}
+      email = ${email}
+    | SHORT
+
+# The content is not interpolated so there is no folding
+$heredoc2 = @(PUPDOCB/L)
+    [user]
+    name = ${[
+      'abc',
+      '123'
+    ]}
+    email = ${email}
+| PUPDOCB
+
+$heredoc3 = @("PUPDOCC"/L)
+    [user]
+        name = ${[
+          'abc',
+          '123'
+        ]}
+        email = ${email}
+    | PUPDOCC
+
+$heredoc4 = @("SOMETHING"/L)
+    [user]
+      name = ${name
+        # Comment Block 1
+        # Comment Block 1
+        # Comment Block 1
+      }
+      email = ${email}
+    | SOMETHING
+HEREDOC
+      end
+
+      let(:expected_ranges) do
+        [
+          lsp_range([0,  12,  4, 0,  nil]),
+          lsp_range([7,  12, 14, 0,  nil]),
+          lsp_range([16, 12, 23, 0,  nil]),
+          lsp_range([18, 17, 21, 9,  nil]),
+          lsp_range([25, 12, 33, 0,  nil]),
+          lsp_range([28,  8, 30, 25, 'comment']),
+        ]
+      end
+
+      it 'returns only matched regions' do
+        subject = PuppetLanguageServer::Manifest::FoldingProvider.new
+        expect(content).not_to include("\r\n")
+        actual_ranges = subject.folding_ranges(doc_store.document_tokens(doc_uri, doc_version))
+        expect_ranges(actual_ranges, expected_ranges)
+      end
+    end
+
+  end
+end

--- a/spec/languageserver/unit/puppet-languageserver/session_state/document_store_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/session_state/document_store_spec.rb
@@ -94,4 +94,39 @@ describe 'PuppetLanguageServer::SessionState::DocumentStore' do
       end
     end
   end
+
+  describe '#document_tokens' do
+    let(:uri) { 'file://something.pp' }
+    let(:content) { 'content' }
+    let(:version) { 1 }
+
+    before(:each) do
+      subject.set_document(uri, content, version)
+    end
+
+    it 'returns nil for documents that do not exist' do
+      expect(subject.document_tokens('file://bad_uri', version)).to be_nil
+    end
+
+    it 'returns nil for document versions that do not exist' do
+      expect(subject.document_tokens(uri, -1)).to be_nil
+    end
+
+    it 'returns tokens for latest document version' do
+      expect(subject.document_tokens(uri)).to_not be_nil
+    end
+
+    it 'caches the document tokens for the same version of the file' do
+      first = subject.document_tokens(uri)
+      second = subject.document_tokens(uri)
+      expect(first.object_id).to eq(second.object_id)
+    end
+
+    it 'recalculates document tokens when the file changes' do
+      first = subject.document_tokens(uri)
+      subject.set_document(uri, content, version + 1)
+      second = subject.document_tokens(uri)
+      expect(first.object_id).to_not eq(second.object_id)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #306 

Previously the Puppet Lexer ignored whitespace and comments and did not generate
any token information. This meant it could not be used for code formatting
purposes. This commit adds a new lexer which sub-classes the original and emits
tokens for comments. Later commits can use this lexer for operations like code
folding and as-you-type formatting.

This commit also memoizes the tokens in the document store so documents do not
need to be lexed multiple times for the same version.

---

Previously the Language Server dod not provide code folding hints, and the
client was left to use its defauly, typically indentation based.  This commit:

* Adds a manifest folding provider, which can extract code folding regions based
  on block comments, multiline comments and blocks of code ( { -> } and [ -> ] )
* Adds many tests to ensure that regions are detected correctly particuarly in
  nested situations, or within HEREDOC strings.
* Note that this folding is only supported on Puppet 6.3.0 and above due to
  the needed features in the Puppet Langauge tokeniser
  
 ---
  
Now that there is a Puppet Manifest Folding provider available, the server
capabilities need to be updated so that clients know to use it. This commit:

* Creates a method on ServerCapabilities to determine if folding is supported
  by the server
* Updates the Service Capabilities to advertise the 'foldingRangeProvider'
  capavility if it is supported but not dynamic registrations
* Updates the Client Settings to send dynamic registrations
  'textDocument/foldingRange' if supported
* Adds a two new settings for Folding: Enabled and Show Last Line
* Refactors the Language Client settings to make it easier to set defaults
* Updated Server to respond to 'textDocument/foldingRange' requests

Adds many tests for the message handler and language client for the new provider

---

Task list

- [x] Add tests for document store that it ejects tokens when a different document version is used