### PR TITLE
(maint) Add port 9000 for dev. container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,9 +10,9 @@
   // Add the IDs of extensions you want installed when the container is created.
   "extensions": [
     "rebornix.Ruby"
-  ]
+  ],
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  // "forwardPorts": [],
+  "forwardPorts": [9000],
   // Use 'postCreateCommand' to run commands after the container is created.
   // "postCreateCommand": "ruby --version",
   // Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.


### PR DESCRIPTION
This commit explicitly adds port 9000 as a port that can be used during
development.  That way the editor services can be run inside the docker
container and VSCode can connect to it over TCP Port 9000.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppet-editor-services/blob/master/CONTRIBUTING.md

and

CODE_OF_CONDUCT - https://github.com/puppetlabs/puppet-editor-services/blob/master/CODE_OF_CONDUCT.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - You are not submitting a pull request from your MASTER branch.
 - YOUR GIT COMMIT MESSAGE FORMAT IS EXTREMELY IMPORTANT. We have a very defined expectation for this format and are sticklers about it. Really, READ the entire Contributing document. It will save you and us pain.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
