### PR TITLE
Fix links to Puppet Agent install guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,12 +268,9 @@ D, [2018-04-17T14:21:10.546834 #12424] DEBUG -- : TCPSRV: Started listening on 1
 ## How to run the Debug Server for Production
 
 * Ensure that Puppet Agent is installed
-
-[Linux](https://docs.puppet.com/puppet/4.10/install_linux.html)
-
-[Windows](https://docs.puppet.com/puppet/4.10/install_windows.html)
-
-[MacOSX](https://docs.puppet.com/puppet/4.10/install_osx.html)
+  * [Linux](https://puppet.com/docs/puppet/7/install_agents.html#install_nix_agents)
+  * [Windows](https://puppet.com/docs/puppet/7/install_agents.html#install_windows_agents)
+  * [MacOSX](https://puppet.com/docs/puppet/7/install_agents.html#install_mac_agents)
 
 
 * Run the `puppet-debugserver` with ruby


### PR DESCRIPTION
The current links point to the documentaion release 4.10 and to the old
docs.puppet.com subdoamin. All three platform specific links now point
to the latest version of the installation guide.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppet-editor-services/blob/master/CONTRIBUTING.md

and

CODE_OF_CONDUCT - https://github.com/puppetlabs/puppet-editor-services/blob/master/CODE_OF_CONDUCT.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - You are not submitting a pull request from your MASTER branch.
 - YOUR GIT COMMIT MESSAGE FORMAT IS EXTREMELY IMPORTANT. We have a very defined expectation for this format and are sticklers about it. Really, READ the entire Contributing document. It will save you and us pain.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
