### PR TITLE
Fix second occurence of links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,9 @@ D, [2018-12-05T15:20:56.374333 #29752] DEBUG -- : TCPSRV: Started listening on l
 ## How to run the Language Server in Production
 
 * Ensure that Puppet Agent is installed
-
-[Linux](https://docs.puppet.com/puppet/4.10/install_linux.html)
-
-[Windows](https://docs.puppet.com/puppet/4.10/install_windows.html)
-
-[MacOSX](https://docs.puppet.com/puppet/4.10/install_osx.html)
-
+  * [Linux](https://puppet.com/docs/puppet/7/install_agents.html#install_nix_agents)
+  * [Windows](https://puppet.com/docs/puppet/7/install_agents.html#install_windows_agents)
+  * [macOS](https://puppet.com/docs/puppet/7/install_agents.html#install_mac_agents)
 
 * Run the `puppet-languageserver` with ruby
 
@@ -270,7 +266,7 @@ D, [2018-04-17T14:21:10.546834 #12424] DEBUG -- : TCPSRV: Started listening on 1
 * Ensure that Puppet Agent is installed
   * [Linux](https://puppet.com/docs/puppet/7/install_agents.html#install_nix_agents)
   * [Windows](https://puppet.com/docs/puppet/7/install_agents.html#install_windows_agents)
-  * [MacOSX](https://puppet.com/docs/puppet/7/install_agents.html#install_mac_agents)
+  * [macOS](https://puppet.com/docs/puppet/7/install_agents.html#install_mac_agents)
 
 
 * Run the `puppet-debugserver` with ruby


### PR DESCRIPTION
The deep links into the documentation actually occur twice. This fixes
the second and additionally adjusts the os name from MacOSX to macOS.

Sorry for having overseen this in the last PR.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppet-editor-services/blob/master/CONTRIBUTING.md

and

CODE_OF_CONDUCT - https://github.com/puppetlabs/puppet-editor-services/blob/master/CODE_OF_CONDUCT.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - You are not submitting a pull request from your MASTER branch.
 - YOUR GIT COMMIT MESSAGE FORMAT IS EXTREMELY IMPORTANT. We have a very defined expectation for this format and are sticklers about it. Really, READ the entire Contributing document. It will save you and us pain.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
