### PR TITLE
(maint) Removal of Puppet 5 and Puppet 6 testing

### DIFF
--- a/.github/workflows/create-test-matrix.ps1
+++ b/.github/workflows/create-test-matrix.ps1
@@ -11,8 +11,6 @@ $OSList =@('ubuntu-latest', 'windows-latest')
 #  - https://www.msys2.org/news/#2021-01-31-aslr-enabled-by-default
 $RubyPuppet = @(
   @{ ruby = '2.7'; puppet_gem_version = '~> 7.0' }
-  @{ ruby = '2.5.8'; puppet_gem_version = '~> 6.0' }
-  @{ ruby = '2.4'; puppet_gem_version = '~> 5.0' }
 )
 
 $OSList | ForEach-Object {
@@ -38,14 +36,6 @@ $OSList | ForEach-Object {
     }
   }
 
-  # Add Version specific Tests
-  $Jobs += @{
-    job_name = 'Puppet 5.1.0 Unit Test'
-    os = $OS
-    ruby = "2.4"
-    puppet_gem_version = "5.1.0"
-    rake_tasks = 'gem_revendor test_languageserver'
-  }
 
   # Add Acceptance tests
   $Jobs += @{


### PR DESCRIPTION
Prior to this commit testing ran on older version of puppet and ruby.

This commit removes old versions that tests are running on.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppet-editor-services/blob/master/CONTRIBUTING.md

and

CODE_OF_CONDUCT - https://github.com/puppetlabs/puppet-editor-services/blob/master/CODE_OF_CONDUCT.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - You are not submitting a pull request from your MASTER branch.
 - YOUR GIT COMMIT MESSAGE FORMAT IS EXTREMELY IMPORTANT. We have a very defined expectation for this format and are sticklers about it. Really, READ the entire Contributing document. It will save you and us pain.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
