### PR TITLE
(Maint) - Update rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -112,3 +112,6 @@ Lint/RaiseException:
 
 Lint/StructNewOverride:
   Enabled: true
+
+Style/OptionalBooleanParameter:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,12 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 # -=-=-=-=-=- WARNING -=-=-=-=-=-
 
 group :development do
-  gem 'rake', '>= 10.4',            :require => false
-  gem 'rspec', '>= 3.2',            :require => false
+  gem 'rake', '>= 10.4',                  :require => false
+  gem 'rspec', '>= 3.2',                  :require => false
 
-  if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create('2.3.0')
-    gem "rubocop", "~> 0.83.0", :require => false, :platforms => [:ruby, :x64_mingw]
-  end
+  gem "rubocop", '= 1.6.1',                            require: false
+  gem "rubocop-performance", '= 1.9.1',                require: false
+  gem "rubocop-rspec", '= 2.0.1',                      require: false
 
   if ENV['PUPPET_GEM_VERSION']
     gem 'puppet', ENV['PUPPET_GEM_VERSION'], :require => false

--- a/lib/dsp/dsp_protocol.rb
+++ b/lib/dsp/dsp_protocol.rb
@@ -19,8 +19,7 @@ module DSP
   #         type: string;
   #     }
   class ProtocolMessage < DSPBase
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :seq, :type # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -37,10 +36,7 @@ module DSP
   #         arguments?: any;
   #     }
   class Request < DSPBase
-    attr_accessor :command # type: string
-    attr_accessor :arguments # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :command, :arguments, :seq, :type # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -64,10 +60,7 @@ module DSP
   #         body?: any;
   #     }
   class Event < DSPBase
-    attr_accessor :event # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :event, :body, :seq, :type # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -106,13 +99,7 @@ module DSP
   #         body?: any;
   #     }
   class Response < DSPBase
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq, :success, :command, :message, :body, :seq, :type # type: number # type: boolean # type: string # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -139,16 +126,11 @@ module DSP
   #         };
   #     }
   class ErrorResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** An optional, structured error message. */
     #            error?: Message;
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -172,10 +154,7 @@ module DSP
   #         arguments?: CancelArguments;
   #     }
   class CancelRequest < DSPBase
-    attr_accessor :arguments # type: CancelArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: CancelArguments # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -203,8 +182,7 @@ module DSP
   #         progressId?: string;
   #     }
   class CancelArguments < DSPBase
-    attr_accessor :requestId # type: number
-    attr_accessor :progressId # type: string
+    attr_accessor :requestId, :progressId # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -222,13 +200,7 @@ module DSP
   # interface CancelResponse extends Response {
   #     }
   class CancelResponse < DSPBase
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq, :success, :command, :message, :body, :seq, :type # type: number # type: boolean # type: string # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -251,10 +223,7 @@ module DSP
   # interface InitializedEvent extends Event {
   #     }
   class InitializedEvent < DSPBase
-    attr_accessor :event # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :event, :body, :seq, :type # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -294,7 +263,7 @@ module DSP
   #         };
   #     }
   class StoppedEvent < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :seq, :type # type: {
     #            /** The reason for the event.
     #                For backward compatibility this string is shown in the UI if the 'description' attribute is missing (but it must not be translated).
     #                Values: 'step', 'breakpoint', 'exception', 'pause', 'entry', 'goto', 'function breakpoint', 'data breakpoint', etc.
@@ -314,9 +283,7 @@ module DSP
     #            */
     #            allThreadsStopped?: boolean;
     #        }
-    attr_accessor :event # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :event # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -337,15 +304,13 @@ module DSP
   #         };
   #     }
   class ContinuedEvent < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :seq, :type # type: {
     #            /** The thread which was continued. */
     #            threadId: number;
     #            /** If 'allThreadsContinued' is true, a debug adapter can announce that all threads have continued. */
     #            allThreadsContinued?: boolean;
     #        }
-    attr_accessor :event # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :event # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -364,13 +329,11 @@ module DSP
   #         };
   #     }
   class ExitedEvent < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :seq, :type # type: {
     #            /** The exit code returned from the debuggee. */
     #            exitCode: number;
     #        }
-    attr_accessor :event # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :event # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -391,15 +354,13 @@ module DSP
   #         };
   #     }
   class TerminatedEvent < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :seq, :type # type: {
     #            /** A debug adapter may set 'restart' to true (or to an arbitrary object) to request that the front end restarts the session.
     #                The value is not interpreted by the client and passed unmodified as an attribute '__restart' to the 'launch' and 'attach' requests.
     #            */
     #            restart?: any;
     #        }
-    attr_accessor :event # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :event # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -427,7 +388,7 @@ module DSP
   #         };
   #     }
   class ThreadEvent < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :seq, :type # type: {
     #            /** The reason for the event.
     #                Values: 'started', 'exited', etc.
     #            */
@@ -435,9 +396,7 @@ module DSP
     #            /** The identifier of the thread. */
     #            threadId: number;
     #        }
-    attr_accessor :event # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :event # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -479,7 +438,7 @@ module DSP
   #         };
   #     }
   class OutputEvent < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :seq, :type # type: {
     #            /** The output category. If not specified, 'console' is assumed.
     #                Values: 'console', 'stdout', 'stderr', 'telemetry', etc.
     #            */
@@ -506,9 +465,7 @@ module DSP
     #            /** Optional data to report. For the 'telemetry' category the data will be sent to telemetry, for the other categories the data is shown in JSON format. */
     #            data?: any;
     #        }
-    attr_accessor :event # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :event # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -531,7 +488,7 @@ module DSP
   #         };
   #     }
   class BreakpointEvent < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :seq, :type # type: {
     #            /** The reason for the event.
     #                Values: 'changed', 'new', 'removed', etc.
     #            */
@@ -539,9 +496,7 @@ module DSP
     #            /** The 'id' attribute is used to find the target breakpoint and the other attributes are used as the new values. */
     #            breakpoint: Breakpoint;
     #        }
-    attr_accessor :event # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :event # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -562,15 +517,13 @@ module DSP
   #         };
   #     }
   class ModuleEvent < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :seq, :type # type: {
     #            /** The reason for the event. */
     #            reason: 'new' | 'changed' | 'removed';
     #            /** The new, changed, or removed module. In case of 'removed' only the module id is used. */
     #            module: Module;
     #        }
-    attr_accessor :event # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :event # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -591,15 +544,13 @@ module DSP
   #         };
   #     }
   class LoadedSourceEvent < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :seq, :type # type: {
     #            /** The reason for the event. */
     #            reason: 'new' | 'changed' | 'removed';
     #            /** The new, changed, or removed source. */
     #            source: Source;
     #        }
-    attr_accessor :event # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :event # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -630,7 +581,7 @@ module DSP
   #         };
   #     }
   class ProcessEvent < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :seq, :type # type: {
     #            /** The logical name of the process. This is usually the full path to process's executable file. Example: /home/example/myproj/program.js. */
     #            name: string;
     #            /** The system process id of the debugged process. This property will be missing for non-system processes. */
@@ -646,9 +597,7 @@ module DSP
     #            /** The size of a pointer or address for this process, in bits. This value may be used by clients when formatting addresses for display. */
     #            pointerSize?: number;
     #        }
-    attr_accessor :event # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :event # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -667,13 +616,11 @@ module DSP
   #         };
   #     }
   class CapabilitiesEvent < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :seq, :type # type: {
     #            /** The set of updated capabilities. */
     #            capabilities: Capabilities;
     #        }
-    attr_accessor :event # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :event # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -710,7 +657,7 @@ module DSP
   #         };
   #     }
   class ProgressStartEvent < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :seq, :type # type: {
     #            /** An ID that must be used in subsequent 'progressUpdate' and 'progressEnd' events to make them refer to the same progress reporting.
     #                IDs must be unique within a debug session.
     #            */
@@ -732,9 +679,7 @@ module DSP
     #            /** Optional progress percentage to display (value range: 0 to 100). If omitted no percentage will be shown. */
     #            percentage?: number;
     #        }
-    attr_accessor :event # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :event # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -757,7 +702,7 @@ module DSP
   #         };
   #     }
   class ProgressUpdateEvent < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :seq, :type # type: {
     #            /** The ID that was introduced in the initial 'progressStart' event. */
     #            progressId: string;
     #            /** Optional, more detailed progress message. If omitted, the previous message (if any) is used. */
@@ -765,9 +710,7 @@ module DSP
     #            /** Optional progress percentage to display (value range: 0 to 100). If omitted no percentage will be shown. */
     #            percentage?: number;
     #        }
-    attr_accessor :event # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :event # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -788,15 +731,13 @@ module DSP
   #         };
   #     }
   class ProgressEndEvent < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :seq, :type # type: {
     #            /** The ID that was introduced in the initial 'ProgressStartEvent'. */
     #            progressId: string;
     #            /** Optional, more detailed progress message. If omitted, the previous message (if any) is used. */
     #            message?: string;
     #        }
-    attr_accessor :event # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :event # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -812,10 +753,7 @@ module DSP
   #         arguments: RunInTerminalRequestArguments;
   #     }
   class RunInTerminalRequest < DSPBase
-    attr_accessor :arguments # type: RunInTerminalRequestArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: RunInTerminalRequestArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -842,11 +780,8 @@ module DSP
   #         };
   #     }
   class RunInTerminalRequestArguments < DSPBase
-    attr_accessor :kind # type: string with value 'integrated' | 'external'
-    attr_accessor :title # type: string
-    attr_accessor :cwd # type: string
-    attr_accessor :args # type: string[]
-    attr_accessor :env # type: {
+    attr_accessor :kind, :title, :cwd, :args, :env # type: string with value 'integrated' | 'external' # type: string # type: string # type: string[] # type: {
+
     #            [key: string]: string | null;
     #        }
 
@@ -875,18 +810,13 @@ module DSP
   #         };
   #     }
   class RunInTerminalResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** The process ID. The value should be less than or equal to 2147483647 (2^31 - 1). */
     #            processId?: number;
     #            /** The process ID of the terminal shell. The value should be less than or equal to 2147483647 (2^31 - 1). */
     #            shellProcessId?: number;
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -910,10 +840,7 @@ module DSP
   #         arguments: InitializeRequestArguments;
   #     }
   class InitializeRequest < DSPBase
-    attr_accessor :arguments # type: InitializeRequestArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: InitializeRequestArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -954,18 +881,7 @@ module DSP
   #         supportsProgressReporting?: boolean;
   #     }
   class InitializeRequestArguments < DSPBase
-    attr_accessor :clientID # type: string
-    attr_accessor :clientName # type: string
-    attr_accessor :adapterID # type: string
-    attr_accessor :locale # type: string
-    attr_accessor :linesStartAt1 # type: boolean
-    attr_accessor :columnsStartAt1 # type: boolean
-    attr_accessor :pathFormat # type: string
-    attr_accessor :supportsVariableType # type: boolean
-    attr_accessor :supportsVariablePaging # type: boolean
-    attr_accessor :supportsRunInTerminalRequest # type: boolean
-    attr_accessor :supportsMemoryReferences # type: boolean
-    attr_accessor :supportsProgressReporting # type: boolean
+    attr_accessor :clientID, :clientName, :adapterID, :locale, :linesStartAt1, :columnsStartAt1, :pathFormat, :supportsVariableType, :supportsVariablePaging, :supportsRunInTerminalRequest, :supportsMemoryReferences, :supportsProgressReporting # type: string # type: string # type: string # type: string # type: boolean # type: boolean # type: string # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -995,13 +911,7 @@ module DSP
   #         body?: Capabilities;
   #     }
   class InitializeResponse < DSPBase
-    attr_accessor :body # type: Capabilities
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :body, :request_seq, :success, :command, :message, :seq, :type # type: Capabilities # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1025,10 +935,7 @@ module DSP
   #         arguments?: ConfigurationDoneArguments;
   #     }
   class ConfigurationDoneRequest < DSPBase
-    attr_accessor :arguments # type: ConfigurationDoneArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: ConfigurationDoneArguments # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1058,13 +965,7 @@ module DSP
   # interface ConfigurationDoneResponse extends Response {
   #     }
   class ConfigurationDoneResponse < DSPBase
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq, :success, :command, :message, :body, :seq, :type # type: number # type: boolean # type: string # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1088,10 +989,7 @@ module DSP
   #         arguments: LaunchRequestArguments;
   #     }
   class LaunchRequest < DSPBase
-    attr_accessor :arguments # type: LaunchRequestArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: LaunchRequestArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -1113,8 +1011,7 @@ module DSP
   #         __restart?: any;
   #     }
   class LaunchRequestArguments < DSPBase
-    attr_accessor :noDebug # type: boolean
-    attr_accessor :__restart # type: any
+    attr_accessor :noDebug, :__restart # type: boolean # type: any
 
     def initialize(initial_hash = nil)
       super
@@ -1132,13 +1029,7 @@ module DSP
   # interface LaunchResponse extends Response {
   #     }
   class LaunchResponse < DSPBase
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq, :success, :command, :message, :body, :seq, :type # type: number # type: boolean # type: string # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1162,10 +1053,7 @@ module DSP
   #         arguments: AttachRequestArguments;
   #     }
   class AttachRequest < DSPBase
-    attr_accessor :arguments # type: AttachRequestArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: AttachRequestArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -1202,13 +1090,7 @@ module DSP
   # interface AttachResponse extends Response {
   #     }
   class AttachResponse < DSPBase
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq, :success, :command, :message, :body, :seq, :type # type: number # type: boolean # type: string # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1232,10 +1114,7 @@ module DSP
   #         arguments?: RestartArguments;
   #     }
   class RestartRequest < DSPBase
-    attr_accessor :arguments # type: RestartArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: RestartArguments # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1265,13 +1144,7 @@ module DSP
   # interface RestartResponse extends Response {
   #     }
   class RestartResponse < DSPBase
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq, :success, :command, :message, :body, :seq, :type # type: number # type: boolean # type: string # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1295,10 +1168,7 @@ module DSP
   #         arguments?: DisconnectArguments;
   #     }
   class DisconnectRequest < DSPBase
-    attr_accessor :arguments # type: DisconnectArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: DisconnectArguments # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1325,8 +1195,7 @@ module DSP
   #         terminateDebuggee?: boolean;
   #     }
   class DisconnectArguments < DSPBase
-    attr_accessor :restart # type: boolean
-    attr_accessor :terminateDebuggee # type: boolean
+    attr_accessor :restart, :terminateDebuggee # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -1344,13 +1213,7 @@ module DSP
   # interface DisconnectResponse extends Response {
   #     }
   class DisconnectResponse < DSPBase
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq, :success, :command, :message, :body, :seq, :type # type: number # type: boolean # type: string # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1374,10 +1237,7 @@ module DSP
   #         arguments?: TerminateArguments;
   #     }
   class TerminateRequest < DSPBase
-    attr_accessor :arguments # type: TerminateArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: TerminateArguments # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1416,13 +1276,7 @@ module DSP
   # interface TerminateResponse extends Response {
   #     }
   class TerminateResponse < DSPBase
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq, :success, :command, :message, :body, :seq, :type # type: number # type: boolean # type: string # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1446,10 +1300,7 @@ module DSP
   #         arguments?: BreakpointLocationsArguments;
   #     }
   class BreakpointLocationsRequest < DSPBase
-    attr_accessor :arguments # type: BreakpointLocationsArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: BreakpointLocationsArguments # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1479,11 +1330,7 @@ module DSP
   #         endColumn?: number;
   #     }
   class BreakpointLocationsArguments < DSPBase
-    attr_accessor :source # type: Source
-    attr_accessor :line # type: number
-    attr_accessor :column # type: number
-    attr_accessor :endLine # type: number
-    attr_accessor :endColumn # type: number
+    attr_accessor :source, :line, :column, :endLine, :endColumn # type: Source # type: number # type: number # type: number # type: number
 
     def initialize(initial_hash = nil)
       super
@@ -1508,16 +1355,11 @@ module DSP
   #         };
   #     }
   class BreakpointLocationsResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** Sorted set of possible breakpoint locations. */
     #            breakpoints: BreakpointLocation[];
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1541,10 +1383,7 @@ module DSP
   #         arguments: SetBreakpointsArguments;
   #     }
   class SetBreakpointsRequest < DSPBase
-    attr_accessor :arguments # type: SetBreakpointsArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: SetBreakpointsArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -1567,10 +1406,7 @@ module DSP
   #         sourceModified?: boolean;
   #     }
   class SetBreakpointsArguments < DSPBase
-    attr_accessor :source # type: Source
-    attr_accessor :breakpoints # type: SourceBreakpoint[]
-    attr_accessor :lines # type: number[]
-    attr_accessor :sourceModified # type: boolean
+    attr_accessor :source, :breakpoints, :lines, :sourceModified # type: Source # type: SourceBreakpoint[] # type: number[] # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -1596,18 +1432,13 @@ module DSP
   #         };
   #     }
   class SetBreakpointsResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** Information about the breakpoints.
     #                The array elements are in the same order as the elements of the 'breakpoints' (or the deprecated 'lines') array in the arguments.
     #            */
     #            breakpoints: Breakpoint[];
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1631,10 +1462,7 @@ module DSP
   #         arguments: SetFunctionBreakpointsArguments;
   #     }
   class SetFunctionBreakpointsRequest < DSPBase
-    attr_accessor :arguments # type: SetFunctionBreakpointsArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: SetFunctionBreakpointsArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -1667,16 +1495,11 @@ module DSP
   #         };
   #     }
   class SetFunctionBreakpointsResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** Information about the breakpoints. The array elements correspond to the elements of the 'breakpoints' array. */
     #            breakpoints: Breakpoint[];
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1700,10 +1523,7 @@ module DSP
   #         arguments: SetExceptionBreakpointsArguments;
   #     }
   class SetExceptionBreakpointsRequest < DSPBase
-    attr_accessor :arguments # type: SetExceptionBreakpointsArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: SetExceptionBreakpointsArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -1724,8 +1544,7 @@ module DSP
   #         exceptionOptions?: ExceptionOptions[];
   #     }
   class SetExceptionBreakpointsArguments < DSPBase
-    attr_accessor :filters # type: string[]
-    attr_accessor :exceptionOptions # type: ExceptionOptions[]
+    attr_accessor :filters, :exceptionOptions # type: string[] # type: ExceptionOptions[]
 
     def initialize(initial_hash = nil)
       super
@@ -1743,13 +1562,7 @@ module DSP
   # interface SetExceptionBreakpointsResponse extends Response {
   #     }
   class SetExceptionBreakpointsResponse < DSPBase
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq, :success, :command, :message, :body, :seq, :type # type: number # type: boolean # type: string # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1773,10 +1586,7 @@ module DSP
   #         arguments: DataBreakpointInfoArguments;
   #     }
   class DataBreakpointInfoRequest < DSPBase
-    attr_accessor :arguments # type: DataBreakpointInfoArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: DataBreakpointInfoArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -1797,8 +1607,7 @@ module DSP
   #         name: string;
   #     }
   class DataBreakpointInfoArguments < DSPBase
-    attr_accessor :variablesReference # type: number
-    attr_accessor :name # type: string
+    attr_accessor :variablesReference, :name # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1826,7 +1635,7 @@ module DSP
   #         };
   #     }
   class DataBreakpointInfoResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** An identifier for the data on which a data breakpoint can be registered with the setDataBreakpoints request or null if no data breakpoint is available. */
     #            dataId: string | null;
     #            /** UI string that describes on what data the breakpoint is set on or why a data breakpoint is not available. */
@@ -1836,12 +1645,7 @@ module DSP
     #            /** Optional attribute indicating that a potential data breakpoint could be persisted across sessions. */
     #            canPersist?: boolean;
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1865,10 +1669,7 @@ module DSP
   #         arguments: SetDataBreakpointsArguments;
   #     }
   class SetDataBreakpointsRequest < DSPBase
-    attr_accessor :arguments # type: SetDataBreakpointsArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: SetDataBreakpointsArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -1901,16 +1702,11 @@ module DSP
   #         };
   #     }
   class SetDataBreakpointsResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** Information about the data breakpoints. The array elements correspond to the elements of the input argument 'breakpoints' array. */
     #            breakpoints: Breakpoint[];
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1934,10 +1730,7 @@ module DSP
   #         arguments: ContinueArguments;
   #     }
   class ContinueRequest < DSPBase
-    attr_accessor :arguments # type: ContinueArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: ContinueArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -1974,18 +1767,13 @@ module DSP
   #         };
   #     }
   class ContinueResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** If true, the 'continue' request has ignored the specified thread and continued all threads instead.
     #                If this attribute is missing a value of 'true' is assumed for backward compatibility.
     #            */
     #            allThreadsContinued?: boolean;
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -2009,10 +1797,7 @@ module DSP
   #         arguments: NextArguments;
   #     }
   class NextRequest < DSPBase
-    attr_accessor :arguments # type: NextArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: NextArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -2041,13 +1826,7 @@ module DSP
   # interface NextResponse extends Response {
   #     }
   class NextResponse < DSPBase
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq, :success, :command, :message, :body, :seq, :type # type: number # type: boolean # type: string # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -2071,10 +1850,7 @@ module DSP
   #         arguments: StepInArguments;
   #     }
   class StepInRequest < DSPBase
-    attr_accessor :arguments # type: StepInArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: StepInArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -2093,8 +1869,7 @@ module DSP
   #         targetId?: number;
   #     }
   class StepInArguments < DSPBase
-    attr_accessor :threadId # type: number
-    attr_accessor :targetId # type: number
+    attr_accessor :threadId, :targetId # type: number # type: number
 
     def initialize(initial_hash = nil)
       super
@@ -2112,13 +1887,7 @@ module DSP
   # interface StepInResponse extends Response {
   #     }
   class StepInResponse < DSPBase
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq, :success, :command, :message, :body, :seq, :type # type: number # type: boolean # type: string # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -2142,10 +1911,7 @@ module DSP
   #         arguments: StepOutArguments;
   #     }
   class StepOutRequest < DSPBase
-    attr_accessor :arguments # type: StepOutArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: StepOutArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -2174,13 +1940,7 @@ module DSP
   # interface StepOutResponse extends Response {
   #     }
   class StepOutResponse < DSPBase
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq, :success, :command, :message, :body, :seq, :type # type: number # type: boolean # type: string # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -2204,10 +1964,7 @@ module DSP
   #         arguments: StepBackArguments;
   #     }
   class StepBackRequest < DSPBase
-    attr_accessor :arguments # type: StepBackArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: StepBackArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -2236,13 +1993,7 @@ module DSP
   # interface StepBackResponse extends Response {
   #     }
   class StepBackResponse < DSPBase
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq, :success, :command, :message, :body, :seq, :type # type: number # type: boolean # type: string # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -2266,10 +2017,7 @@ module DSP
   #         arguments: ReverseContinueArguments;
   #     }
   class ReverseContinueRequest < DSPBase
-    attr_accessor :arguments # type: ReverseContinueArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: ReverseContinueArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -2298,13 +2046,7 @@ module DSP
   # interface ReverseContinueResponse extends Response {
   #     }
   class ReverseContinueResponse < DSPBase
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq, :success, :command, :message, :body, :seq, :type # type: number # type: boolean # type: string # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -2328,10 +2070,7 @@ module DSP
   #         arguments: RestartFrameArguments;
   #     }
   class RestartFrameRequest < DSPBase
-    attr_accessor :arguments # type: RestartFrameArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: RestartFrameArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -2360,13 +2099,7 @@ module DSP
   # interface RestartFrameResponse extends Response {
   #     }
   class RestartFrameResponse < DSPBase
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq, :success, :command, :message, :body, :seq, :type # type: number # type: boolean # type: string # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -2390,10 +2123,7 @@ module DSP
   #         arguments: GotoArguments;
   #     }
   class GotoRequest < DSPBase
-    attr_accessor :arguments # type: GotoArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: GotoArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -2412,8 +2142,7 @@ module DSP
   #         targetId: number;
   #     }
   class GotoArguments < DSPBase
-    attr_accessor :threadId # type: number
-    attr_accessor :targetId # type: number
+    attr_accessor :threadId, :targetId # type: number # type: number
 
     def from_h!(value)
       value = {} if value.nil?
@@ -2426,13 +2155,7 @@ module DSP
   # interface GotoResponse extends Response {
   #     }
   class GotoResponse < DSPBase
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq, :success, :command, :message, :body, :seq, :type # type: number # type: boolean # type: string # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -2456,10 +2179,7 @@ module DSP
   #         arguments: PauseArguments;
   #     }
   class PauseRequest < DSPBase
-    attr_accessor :arguments # type: PauseArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: PauseArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -2488,13 +2208,7 @@ module DSP
   # interface PauseResponse extends Response {
   #     }
   class PauseResponse < DSPBase
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq, :success, :command, :message, :body, :seq, :type # type: number # type: boolean # type: string # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -2518,10 +2232,7 @@ module DSP
   #         arguments: StackTraceArguments;
   #     }
   class StackTraceRequest < DSPBase
-    attr_accessor :arguments # type: StackTraceArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: StackTraceArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -2546,10 +2257,7 @@ module DSP
   #         format?: StackFrameFormat;
   #     }
   class StackTraceArguments < DSPBase
-    attr_accessor :threadId # type: number
-    attr_accessor :startFrame # type: number
-    attr_accessor :levels # type: number
-    attr_accessor :format # type: StackFrameFormat
+    attr_accessor :threadId, :startFrame, :levels, :format # type: number # type: number # type: number # type: StackFrameFormat
 
     def initialize(initial_hash = nil)
       super
@@ -2577,7 +2285,7 @@ module DSP
   #         };
   #     }
   class StackTraceResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** The frames of the stackframe. If the array has length zero, there are no stackframes available.
     #                This means that there is no location information available.
     #            */
@@ -2585,12 +2293,7 @@ module DSP
     #            /** The total number of frames available. */
     #            totalFrames?: number;
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -2614,10 +2317,7 @@ module DSP
   #         arguments: ScopesArguments;
   #     }
   class ScopesRequest < DSPBase
-    attr_accessor :arguments # type: ScopesArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: ScopesArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -2650,16 +2350,11 @@ module DSP
   #         };
   #     }
   class ScopesResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** The scopes of the stackframe. If the array has length zero, there are no scopes available. */
     #            scopes: Scope[];
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -2683,10 +2378,7 @@ module DSP
   #         arguments: VariablesArguments;
   #     }
   class VariablesRequest < DSPBase
-    attr_accessor :arguments # type: VariablesArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: VariablesArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -2713,11 +2405,7 @@ module DSP
   #         format?: ValueFormat;
   #     }
   class VariablesArguments < DSPBase
-    attr_accessor :variablesReference # type: number
-    attr_accessor :filter # type: string with value 'indexed' | 'named'
-    attr_accessor :start # type: number
-    attr_accessor :count # type: number
-    attr_accessor :format # type: ValueFormat
+    attr_accessor :variablesReference, :filter, :start, :count, :format # type: number # type: string with value 'indexed' | 'named' # type: number # type: number # type: ValueFormat
 
     def initialize(initial_hash = nil)
       super
@@ -2742,16 +2430,11 @@ module DSP
   #         };
   #     }
   class VariablesResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** All (or a range) of variables for the given variable reference. */
     #            variables: Variable[];
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -2775,10 +2458,7 @@ module DSP
   #         arguments: SetVariableArguments;
   #     }
   class SetVariableRequest < DSPBase
-    attr_accessor :arguments # type: SetVariableArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: SetVariableArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -2801,10 +2481,7 @@ module DSP
   #         format?: ValueFormat;
   #     }
   class SetVariableArguments < DSPBase
-    attr_accessor :variablesReference # type: number
-    attr_accessor :name # type: string
-    attr_accessor :value # type: string
-    attr_accessor :format # type: ValueFormat
+    attr_accessor :variablesReference, :name, :value, :format # type: number # type: string # type: string # type: ValueFormat
 
     def initialize(initial_hash = nil)
       super
@@ -2844,7 +2521,7 @@ module DSP
   #         };
   #     }
   class SetVariableResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** The new value of the variable. */
     #            value: string;
     #            /** The type of the new value. Typically shown in the UI when hovering over the value. */
@@ -2864,12 +2541,7 @@ module DSP
     #            */
     #            indexedVariables?: number;
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -2893,10 +2565,7 @@ module DSP
   #         arguments: SourceArguments;
   #     }
   class SourceRequest < DSPBase
-    attr_accessor :arguments # type: SourceArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: SourceArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -2917,8 +2586,7 @@ module DSP
   #         sourceReference: number;
   #     }
   class SourceArguments < DSPBase
-    attr_accessor :source # type: Source
-    attr_accessor :sourceReference # type: number
+    attr_accessor :source, :sourceReference # type: Source # type: number
 
     def initialize(initial_hash = nil)
       super
@@ -2942,18 +2610,13 @@ module DSP
   #         };
   #     }
   class SourceResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** Content of the source reference. */
     #            content: string;
     #            /** Optional content type (mime type) of the source. */
     #            mimeType?: string;
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -2976,10 +2639,7 @@ module DSP
   # interface ThreadsRequest extends Request {
   #     }
   class ThreadsRequest < DSPBase
-    attr_accessor :command # type: string
-    attr_accessor :arguments # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :command, :arguments, :seq, :type # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -3003,16 +2663,11 @@ module DSP
   #         };
   #     }
   class ThreadsResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** All threads. */
     #            threads: Thread[];
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -3036,10 +2691,7 @@ module DSP
   #         arguments: TerminateThreadsArguments;
   #     }
   class TerminateThreadsRequest < DSPBase
-    attr_accessor :arguments # type: TerminateThreadsArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: TerminateThreadsArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -3073,13 +2725,7 @@ module DSP
   # interface TerminateThreadsResponse extends Response {
   #     }
   class TerminateThreadsResponse < DSPBase
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :body # type: any
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq, :success, :command, :message, :body, :seq, :type # type: number # type: boolean # type: string # type: string # type: any # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -3103,10 +2749,7 @@ module DSP
   #         arguments: ModulesArguments;
   #     }
   class ModulesRequest < DSPBase
-    attr_accessor :arguments # type: ModulesArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: ModulesArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -3125,8 +2768,7 @@ module DSP
   #         moduleCount?: number;
   #     }
   class ModulesArguments < DSPBase
-    attr_accessor :startModule # type: number
-    attr_accessor :moduleCount # type: number
+    attr_accessor :startModule, :moduleCount # type: number # type: number
 
     def initialize(initial_hash = nil)
       super
@@ -3150,18 +2792,13 @@ module DSP
   #         };
   #     }
   class ModulesResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** All modules or range of modules. */
     #            modules: Module[];
     #            /** The total number of modules available. */
     #            totalModules?: number;
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -3185,10 +2822,7 @@ module DSP
   #         arguments?: LoadedSourcesArguments;
   #     }
   class LoadedSourcesRequest < DSPBase
-    attr_accessor :arguments # type: LoadedSourcesArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: LoadedSourcesArguments # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -3222,16 +2856,11 @@ module DSP
   #         };
   #     }
   class LoadedSourcesResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** Set of loaded sources. */
     #            sources: Source[];
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -3255,10 +2884,7 @@ module DSP
   #         arguments: EvaluateArguments;
   #     }
   class EvaluateRequest < DSPBase
-    attr_accessor :arguments # type: EvaluateArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: EvaluateArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -3291,10 +2917,7 @@ module DSP
   #         format?: ValueFormat;
   #     }
   class EvaluateArguments < DSPBase
-    attr_accessor :expression # type: string
-    attr_accessor :frameId # type: number
-    attr_accessor :context # type: string
-    attr_accessor :format # type: ValueFormat
+    attr_accessor :expression, :frameId, :context, :format # type: string # type: number # type: string # type: ValueFormat
 
     def initialize(initial_hash = nil)
       super
@@ -3343,7 +2966,7 @@ module DSP
   #         };
   #     }
   class EvaluateResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** The result of the evaluate request. */
     #            result: string;
     #            /** The optional type of the evaluate result.
@@ -3372,12 +2995,7 @@ module DSP
     #            */
     #            memoryReference?: string;
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -3401,10 +3019,7 @@ module DSP
   #         arguments: SetExpressionArguments;
   #     }
   class SetExpressionRequest < DSPBase
-    attr_accessor :arguments # type: SetExpressionArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: SetExpressionArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -3427,10 +3042,7 @@ module DSP
   #         format?: ValueFormat;
   #     }
   class SetExpressionArguments < DSPBase
-    attr_accessor :expression # type: string
-    attr_accessor :value # type: string
-    attr_accessor :frameId # type: number
-    attr_accessor :format # type: ValueFormat
+    attr_accessor :expression, :value, :frameId, :format # type: string # type: string # type: number # type: ValueFormat
 
     def initialize(initial_hash = nil)
       super
@@ -3474,7 +3086,7 @@ module DSP
   #         };
   #     }
   class SetExpressionResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** The new value of the expression. */
     #            value: string;
     #            /** The optional type of the value.
@@ -3498,12 +3110,7 @@ module DSP
     #            */
     #            indexedVariables?: number;
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -3527,10 +3134,7 @@ module DSP
   #         arguments: StepInTargetsArguments;
   #     }
   class StepInTargetsRequest < DSPBase
-    attr_accessor :arguments # type: StepInTargetsArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: StepInTargetsArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -3563,16 +3167,11 @@ module DSP
   #         };
   #     }
   class StepInTargetsResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** The possible stepIn targets of the specified source location. */
     #            targets: StepInTarget[];
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -3596,10 +3195,7 @@ module DSP
   #         arguments: GotoTargetsArguments;
   #     }
   class GotoTargetsRequest < DSPBase
-    attr_accessor :arguments # type: GotoTargetsArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: GotoTargetsArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -3620,9 +3216,7 @@ module DSP
   #         column?: number;
   #     }
   class GotoTargetsArguments < DSPBase
-    attr_accessor :source # type: Source
-    attr_accessor :line # type: number
-    attr_accessor :column # type: number
+    attr_accessor :source, :line, :column # type: Source # type: number # type: number
 
     def initialize(initial_hash = nil)
       super
@@ -3645,16 +3239,11 @@ module DSP
   #         };
   #     }
   class GotoTargetsResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** The possible goto targets of the specified location. */
     #            targets: GotoTarget[];
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -3678,10 +3267,7 @@ module DSP
   #         arguments: CompletionsArguments;
   #     }
   class CompletionsRequest < DSPBase
-    attr_accessor :arguments # type: CompletionsArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: CompletionsArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -3704,10 +3290,7 @@ module DSP
   #         line?: number;
   #     }
   class CompletionsArguments < DSPBase
-    attr_accessor :frameId # type: number
-    attr_accessor :text # type: string
-    attr_accessor :column # type: number
-    attr_accessor :line # type: number
+    attr_accessor :frameId, :text, :column, :line # type: number # type: string # type: number # type: number
 
     def initialize(initial_hash = nil)
       super
@@ -3731,16 +3314,11 @@ module DSP
   #         };
   #     }
   class CompletionsResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** The possible completions for . */
     #            targets: CompletionItem[];
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -3764,10 +3342,7 @@ module DSP
   #         arguments: ExceptionInfoArguments;
   #     }
   class ExceptionInfoRequest < DSPBase
-    attr_accessor :arguments # type: ExceptionInfoArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: ExceptionInfoArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -3806,7 +3381,7 @@ module DSP
   #         };
   #     }
   class ExceptionInfoResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** ID of the exception that was thrown. */
     #            exceptionId: string;
     #            /** Descriptive text for the exception provided by the debug adapter. */
@@ -3816,12 +3391,7 @@ module DSP
     #            /** Detailed information about the exception. */
     #            details?: ExceptionDetails;
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -3845,10 +3415,7 @@ module DSP
   #         arguments: ReadMemoryArguments;
   #     }
   class ReadMemoryRequest < DSPBase
-    attr_accessor :arguments # type: ReadMemoryArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: ReadMemoryArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -3869,9 +3436,7 @@ module DSP
   #         count: number;
   #     }
   class ReadMemoryArguments < DSPBase
-    attr_accessor :memoryReference # type: string
-    attr_accessor :offset # type: number
-    attr_accessor :count # type: number
+    attr_accessor :memoryReference, :offset, :count # type: string # type: number # type: number
 
     def initialize(initial_hash = nil)
       super
@@ -3902,7 +3467,7 @@ module DSP
   #         };
   #     }
   class ReadMemoryResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** The address of the first byte of data returned.
     #                Treated as a hex value if prefixed with '0x', or as a decimal value otherwise.
     #            */
@@ -3914,12 +3479,7 @@ module DSP
     #            /** The bytes read from memory, encoded using base64. */
     #            data?: string;
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -3943,10 +3503,7 @@ module DSP
   #         arguments: DisassembleArguments;
   #     }
   class DisassembleRequest < DSPBase
-    attr_accessor :arguments # type: DisassembleArguments
-    attr_accessor :command # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :arguments, :command, :seq, :type # type: DisassembleArguments # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -3973,11 +3530,7 @@ module DSP
   #         resolveSymbols?: boolean;
   #     }
   class DisassembleArguments < DSPBase
-    attr_accessor :memoryReference # type: string
-    attr_accessor :offset # type: number
-    attr_accessor :instructionOffset # type: number
-    attr_accessor :instructionCount # type: number
-    attr_accessor :resolveSymbols # type: boolean
+    attr_accessor :memoryReference, :offset, :instructionOffset, :instructionCount, :resolveSymbols # type: string # type: number # type: number # type: number # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -4002,16 +3555,11 @@ module DSP
   #         };
   #     }
   class DisassembleResponse < DSPBase
-    attr_accessor :body # type: {
+    attr_accessor :body, :success, :command, :message, :seq, :type # type: {
     #            /** The list of disassembled instructions. */
     #            instructions: DisassembledInstruction[];
     #        }
-    attr_accessor :request_seq # type: number
-    attr_accessor :success # type: boolean
-    attr_accessor :command # type: string
-    attr_accessor :message # type: string
-    attr_accessor :seq # type: number
-    attr_accessor :type # type: string
+    attr_accessor :request_seq # type: number # type: boolean # type: string # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -4100,39 +3648,7 @@ module DSP
   #         supportsClipboardContext?: boolean;
   #     }
   class Capabilities < DSPBase
-    attr_accessor :supportsConfigurationDoneRequest # type: boolean
-    attr_accessor :supportsFunctionBreakpoints # type: boolean
-    attr_accessor :supportsConditionalBreakpoints # type: boolean
-    attr_accessor :supportsHitConditionalBreakpoints # type: boolean
-    attr_accessor :supportsEvaluateForHovers # type: boolean
-    attr_accessor :exceptionBreakpointFilters # type: ExceptionBreakpointsFilter[]
-    attr_accessor :supportsStepBack # type: boolean
-    attr_accessor :supportsSetVariable # type: boolean
-    attr_accessor :supportsRestartFrame # type: boolean
-    attr_accessor :supportsGotoTargetsRequest # type: boolean
-    attr_accessor :supportsStepInTargetsRequest # type: boolean
-    attr_accessor :supportsCompletionsRequest # type: boolean
-    attr_accessor :completionTriggerCharacters # type: string[]
-    attr_accessor :supportsModulesRequest # type: boolean
-    attr_accessor :additionalModuleColumns # type: ColumnDescriptor[]
-    attr_accessor :supportedChecksumAlgorithms # type: ChecksumAlgorithm[]
-    attr_accessor :supportsRestartRequest # type: boolean
-    attr_accessor :supportsExceptionOptions # type: boolean
-    attr_accessor :supportsValueFormattingOptions # type: boolean
-    attr_accessor :supportsExceptionInfoRequest # type: boolean
-    attr_accessor :supportTerminateDebuggee # type: boolean
-    attr_accessor :supportsDelayedStackTraceLoading # type: boolean
-    attr_accessor :supportsLoadedSourcesRequest # type: boolean
-    attr_accessor :supportsLogPoints # type: boolean
-    attr_accessor :supportsTerminateThreadsRequest # type: boolean
-    attr_accessor :supportsSetExpression # type: boolean
-    attr_accessor :supportsTerminateRequest # type: boolean
-    attr_accessor :supportsDataBreakpoints # type: boolean
-    attr_accessor :supportsReadMemoryRequest # type: boolean
-    attr_accessor :supportsDisassembleRequest # type: boolean
-    attr_accessor :supportsCancelRequest # type: boolean
-    attr_accessor :supportsBreakpointLocationsRequest # type: boolean
-    attr_accessor :supportsClipboardContext # type: boolean
+    attr_accessor :supportsConfigurationDoneRequest, :supportsFunctionBreakpoints, :supportsConditionalBreakpoints, :supportsHitConditionalBreakpoints, :supportsEvaluateForHovers, :exceptionBreakpointFilters, :supportsStepBack, :supportsSetVariable, :supportsRestartFrame, :supportsGotoTargetsRequest, :supportsStepInTargetsRequest, :supportsCompletionsRequest, :completionTriggerCharacters, :supportsModulesRequest, :additionalModuleColumns, :supportedChecksumAlgorithms, :supportsRestartRequest, :supportsExceptionOptions, :supportsValueFormattingOptions, :supportsExceptionInfoRequest, :supportTerminateDebuggee, :supportsDelayedStackTraceLoading, :supportsLoadedSourcesRequest, :supportsLogPoints, :supportsTerminateThreadsRequest, :supportsSetExpression, :supportsTerminateRequest, :supportsDataBreakpoints, :supportsReadMemoryRequest, :supportsDisassembleRequest, :supportsCancelRequest, :supportsBreakpointLocationsRequest, :supportsClipboardContext # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean # type: ExceptionBreakpointsFilter[] # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean # type: string[] # type: boolean # type: ColumnDescriptor[] # type: ChecksumAlgorithm[] # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -4187,9 +3703,7 @@ module DSP
   #         default?: boolean;
   #     }
   class ExceptionBreakpointsFilter < DSPBase
-    attr_accessor :filter # type: string
-    attr_accessor :label # type: string
-    attr_accessor :default # type: boolean
+    attr_accessor :filter, :label, :default # type: string # type: string # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -4226,15 +3740,10 @@ module DSP
   #         urlLabel?: string;
   #     }
   class Message < DSPBase
-    attr_accessor :id # type: number
-    attr_accessor :format # type: string
-    attr_accessor :variables # type: {
+    attr_accessor :id, :format, :variables, :showUser, :url, :urlLabel # type: number # type: string # type: {
     #            [key: string]: string;
     #        }
-    attr_accessor :sendTelemetry # type: boolean
-    attr_accessor :showUser # type: boolean
-    attr_accessor :url # type: string
-    attr_accessor :urlLabel # type: string
+    attr_accessor :sendTelemetry # type: boolean # type: boolean # type: string # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -4281,16 +3790,7 @@ module DSP
   #         addressRange?: string;
   #     }
   class Module < DSPBase
-    attr_accessor :id # type: number | string
-    attr_accessor :name # type: string
-    attr_accessor :path # type: string
-    attr_accessor :isOptimized # type: boolean
-    attr_accessor :isUserCode # type: boolean
-    attr_accessor :version # type: string
-    attr_accessor :symbolStatus # type: string
-    attr_accessor :symbolFilePath # type: string
-    attr_accessor :dateTimeStamp # type: string
-    attr_accessor :addressRange # type: string
+    attr_accessor :id, :name, :path, :isOptimized, :isUserCode, :version, :symbolStatus, :symbolFilePath, :dateTimeStamp, :addressRange # type: number | string # type: string # type: string # type: boolean # type: boolean # type: string # type: string # type: string # type: string # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -4326,11 +3826,7 @@ module DSP
   #         width?: number;
   #     }
   class ColumnDescriptor < DSPBase
-    attr_accessor :attributeName # type: string
-    attr_accessor :label # type: string
-    attr_accessor :format # type: string
-    attr_accessor :type # type: string with value 'string' | 'number' | 'boolean' | 'unixTimestampUTC'
-    attr_accessor :width # type: number
+    attr_accessor :attributeName, :label, :format, :type, :width # type: string # type: string # type: string # type: string with value 'string' | 'number' | 'boolean' | 'unixTimestampUTC' # type: number
 
     def initialize(initial_hash = nil)
       super
@@ -4368,8 +3864,7 @@ module DSP
   #         name: string;
   #     }
   class Thread < DSPBase
-    attr_accessor :id # type: number
-    attr_accessor :name # type: string
+    attr_accessor :id, :name # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -4409,14 +3904,7 @@ module DSP
   #         checksums?: Checksum[];
   #     }
   class Source < DSPBase
-    attr_accessor :name # type: string
-    attr_accessor :path # type: string
-    attr_accessor :sourceReference # type: number
-    attr_accessor :presentationHint # type: string with value 'normal' | 'emphasize' | 'deemphasize'
-    attr_accessor :origin # type: string
-    attr_accessor :sources # type: Source[]
-    attr_accessor :adapterData # type: any
-    attr_accessor :checksums # type: Checksum[]
+    attr_accessor :name, :path, :sourceReference, :presentationHint, :origin, :sources, :adapterData, :checksums # type: string # type: string # type: number # type: string with value 'normal' | 'emphasize' | 'deemphasize' # type: string # type: Source[] # type: any # type: Checksum[]
 
     def initialize(initial_hash = nil)
       super
@@ -4464,16 +3952,7 @@ module DSP
   #         presentationHint?: 'normal' | 'label' | 'subtle';
   #     }
   class StackFrame < DSPBase
-    attr_accessor :id # type: number
-    attr_accessor :name # type: string
-    attr_accessor :source # type: Source
-    attr_accessor :line # type: number
-    attr_accessor :column # type: number
-    attr_accessor :endLine # type: number
-    attr_accessor :endColumn # type: number
-    attr_accessor :instructionPointerReference # type: string
-    attr_accessor :moduleId # type: number | string
-    attr_accessor :presentationHint # type: string with value 'normal' | 'label' | 'subtle'
+    attr_accessor :id, :name, :source, :line, :column, :endLine, :endColumn, :instructionPointerReference, :moduleId, :presentationHint # type: number # type: string # type: Source # type: number # type: number # type: number # type: number # type: string # type: number | string # type: string with value 'normal' | 'label' | 'subtle'
 
     def initialize(initial_hash = nil)
       super
@@ -4531,17 +4010,7 @@ module DSP
   #         endColumn?: number;
   #     }
   class Scope < DSPBase
-    attr_accessor :name # type: string
-    attr_accessor :presentationHint # type: string
-    attr_accessor :variablesReference # type: number
-    attr_accessor :namedVariables # type: number
-    attr_accessor :indexedVariables # type: number
-    attr_accessor :expensive # type: boolean
-    attr_accessor :source # type: Source
-    attr_accessor :line # type: number
-    attr_accessor :column # type: number
-    attr_accessor :endLine # type: number
-    attr_accessor :endColumn # type: number
+    attr_accessor :name, :presentationHint, :variablesReference, :namedVariables, :indexedVariables, :expensive, :source, :line, :column, :endLine, :endColumn # type: string # type: string # type: number # type: number # type: number # type: boolean # type: Source # type: number # type: number # type: number # type: number
 
     def initialize(initial_hash = nil)
       super
@@ -4594,15 +4063,7 @@ module DSP
   #         memoryReference?: string;
   #     }
   class Variable < DSPBase
-    attr_accessor :name # type: string
-    attr_accessor :value # type: string
-    attr_accessor :type # type: string
-    attr_accessor :presentationHint # type: VariablePresentationHint
-    attr_accessor :evaluateName # type: string
-    attr_accessor :variablesReference # type: number
-    attr_accessor :namedVariables # type: number
-    attr_accessor :indexedVariables # type: number
-    attr_accessor :memoryReference # type: string
+    attr_accessor :name, :value, :type, :presentationHint, :evaluateName, :variablesReference, :namedVariables, :indexedVariables, :memoryReference # type: string # type: string # type: string # type: VariablePresentationHint # type: string # type: number # type: number # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -4660,9 +4121,7 @@ module DSP
   #         visibility?: string;
   #     }
   class VariablePresentationHint < DSPBase
-    attr_accessor :kind # type: string
-    attr_accessor :attributes # type: string[]
-    attr_accessor :visibility # type: string
+    attr_accessor :kind, :attributes, :visibility # type: string # type: string[] # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -4689,10 +4148,7 @@ module DSP
   #         endColumn?: number;
   #     }
   class BreakpointLocation < DSPBase
-    attr_accessor :line # type: number
-    attr_accessor :column # type: number
-    attr_accessor :endLine # type: number
-    attr_accessor :endColumn # type: number
+    attr_accessor :line, :column, :endLine, :endColumn # type: number # type: number # type: number # type: number
 
     def initialize(initial_hash = nil)
       super
@@ -4730,11 +4186,7 @@ module DSP
   #         logMessage?: string;
   #     }
   class SourceBreakpoint < DSPBase
-    attr_accessor :line # type: number
-    attr_accessor :column # type: number
-    attr_accessor :condition # type: string
-    attr_accessor :hitCondition # type: string
-    attr_accessor :logMessage # type: string
+    attr_accessor :line, :column, :condition, :hitCondition, :logMessage # type: number # type: number # type: string # type: string # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -4766,9 +4218,7 @@ module DSP
   #         hitCondition?: string;
   #     }
   class FunctionBreakpoint < DSPBase
-    attr_accessor :name # type: string
-    attr_accessor :condition # type: string
-    attr_accessor :hitCondition # type: string
+    attr_accessor :name, :condition, :hitCondition # type: string # type: string # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -4797,10 +4247,7 @@ module DSP
   #         hitCondition?: string;
   #     }
   class DataBreakpoint < DSPBase
-    attr_accessor :dataId # type: string
-    attr_accessor :accessType # type: DataBreakpointAccessType
-    attr_accessor :condition # type: string
-    attr_accessor :hitCondition # type: string
+    attr_accessor :dataId, :accessType, :condition, :hitCondition # type: string # type: DataBreakpointAccessType # type: string # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -4840,14 +4287,7 @@ module DSP
   #         endColumn?: number;
   #     }
   class Breakpoint < DSPBase
-    attr_accessor :id # type: number
-    attr_accessor :verified # type: boolean
-    attr_accessor :message # type: string
-    attr_accessor :source # type: Source
-    attr_accessor :line # type: number
-    attr_accessor :column # type: number
-    attr_accessor :endLine # type: number
-    attr_accessor :endColumn # type: number
+    attr_accessor :id, :verified, :message, :source, :line, :column, :endLine, :endColumn # type: number # type: boolean # type: string # type: Source # type: number # type: number # type: number # type: number
 
     def initialize(initial_hash = nil)
       super
@@ -4875,8 +4315,7 @@ module DSP
   #         label: string;
   #     }
   class StepInTarget < DSPBase
-    attr_accessor :id # type: number
-    attr_accessor :label # type: string
+    attr_accessor :id, :label # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -4903,13 +4342,7 @@ module DSP
   #         instructionPointerReference?: string;
   #     }
   class GotoTarget < DSPBase
-    attr_accessor :id # type: number
-    attr_accessor :label # type: string
-    attr_accessor :line # type: number
-    attr_accessor :column # type: number
-    attr_accessor :endLine # type: number
-    attr_accessor :endColumn # type: number
-    attr_accessor :instructionPointerReference # type: string
+    attr_accessor :id, :label, :line, :column, :endLine, :endColumn, :instructionPointerReference # type: number # type: string # type: number # type: number # type: number # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -4958,14 +4391,7 @@ module DSP
   #         selectionLength?: number;
   #     }
   class CompletionItem < DSPBase
-    attr_accessor :label # type: string
-    attr_accessor :text # type: string
-    attr_accessor :sortText # type: string
-    attr_accessor :type # type: CompletionItemType
-    attr_accessor :start # type: number
-    attr_accessor :length # type: number
-    attr_accessor :selectionStart # type: number
-    attr_accessor :selectionLength # type: number
+    attr_accessor :label, :text, :sortText, :type, :start, :length, :selectionStart, :selectionLength # type: string # type: string # type: string # type: CompletionItemType # type: number # type: number # type: number # type: number
 
     def initialize(initial_hash = nil)
       super
@@ -4993,8 +4419,7 @@ module DSP
   #         checksum: string;
   #     }
   class Checksum < DSPBase
-    attr_accessor :algorithm # type: ChecksumAlgorithm
-    attr_accessor :checksum # type: string
+    attr_accessor :algorithm, :checksum # type: ChecksumAlgorithm # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -5040,14 +4465,7 @@ module DSP
   #         includeAll?: boolean;
   #     }
   class StackFrameFormat < DSPBase
-    attr_accessor :parameters # type: boolean
-    attr_accessor :parameterTypes # type: boolean
-    attr_accessor :parameterNames # type: boolean
-    attr_accessor :parameterValues # type: boolean
-    attr_accessor :line # type: boolean
-    attr_accessor :module # type: boolean
-    attr_accessor :includeAll # type: boolean
-    attr_accessor :hex # type: boolean
+    attr_accessor :parameters, :parameterTypes, :parameterNames, :parameterValues, :line, :module, :includeAll, :hex # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -5077,8 +4495,7 @@ module DSP
   #         breakMode: ExceptionBreakMode;
   #     }
   class ExceptionOptions < DSPBase
-    attr_accessor :path # type: ExceptionPathSegment[]
-    attr_accessor :breakMode # type: ExceptionBreakMode
+    attr_accessor :path, :breakMode # type: ExceptionPathSegment[] # type: ExceptionBreakMode
 
     def initialize(initial_hash = nil)
       super
@@ -5100,8 +4517,7 @@ module DSP
   #         names: string[];
   #     }
   class ExceptionPathSegment < DSPBase
-    attr_accessor :negate # type: boolean
-    attr_accessor :names # type: string[]
+    attr_accessor :negate, :names # type: boolean # type: string[]
 
     def initialize(initial_hash = nil)
       super
@@ -5131,12 +4547,7 @@ module DSP
   #         innerException?: ExceptionDetails[];
   #     }
   class ExceptionDetails < DSPBase
-    attr_accessor :message # type: string
-    attr_accessor :typeName # type: string
-    attr_accessor :fullTypeName # type: string
-    attr_accessor :evaluateName # type: string
-    attr_accessor :stackTrace # type: string
-    attr_accessor :innerException # type: ExceptionDetails[]
+    attr_accessor :message, :typeName, :fullTypeName, :evaluateName, :stackTrace, :innerException # type: string # type: string # type: string # type: string # type: string # type: ExceptionDetails[]
 
     def initialize(initial_hash = nil)
       super
@@ -5179,15 +4590,7 @@ module DSP
   #         endColumn?: number;
   #     }
   class DisassembledInstruction < DSPBase
-    attr_accessor :address # type: string
-    attr_accessor :instructionBytes # type: string
-    attr_accessor :instruction # type: string
-    attr_accessor :symbol # type: string
-    attr_accessor :location # type: Source
-    attr_accessor :line # type: number
-    attr_accessor :column # type: number
-    attr_accessor :endLine # type: number
-    attr_accessor :endColumn # type: number
+    attr_accessor :address, :instructionBytes, :instruction, :symbol, :location, :line, :column, :endLine, :endColumn # type: string # type: string # type: string # type: string # type: Source # type: number # type: number # type: number # type: number
 
     def initialize(initial_hash = nil)
       super

--- a/lib/lsp/lsp_custom.rb
+++ b/lib/lsp/lsp_custom.rb
@@ -14,13 +14,7 @@ module LSP
   #   classesLoaded: boolean;
   # }
   class PuppetVersion < LSPBase
-    attr_accessor :puppetVersion # type: string
-    attr_accessor :facterVersion # type: string
-    attr_accessor :languageServerVersion # type: string
-    attr_accessor :factsLoaded # type: boolean
-    attr_accessor :functionsLoaded # type: boolean
-    attr_accessor :typesLoaded # type: boolean
-    attr_accessor :classesLoaded # type: boolean
+    attr_accessor :puppetVersion, :facterVersion, :languageServerVersion, :factsLoaded, :functionsLoaded, :typesLoaded, :classesLoaded # type: string # type: string # type: string # type: boolean # type: boolean # type: boolean # type: boolean
 
     def from_h!(value)
       value = {} if value.nil?
@@ -40,8 +34,7 @@ module LSP
   #   error: string;
   # }
   class PuppetFactResponse < LSPBase
-    attr_accessor :facts # type: string
-    attr_accessor :error # type: string
+    attr_accessor :facts, :error # type: string # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -61,8 +54,7 @@ module LSP
   #   error: string;
   # }
   class PuppetResourceResponse < LSPBase
-    attr_accessor :data # type: string
-    attr_accessor :error # type: string
+    attr_accessor :data, :error # type: string # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -82,9 +74,7 @@ module LSP
   #   data: string;
   # }
   class PuppetNodeGraphResponse < LSPBase
-    attr_accessor :vertices # type: string
-    attr_accessor :edges # type: string
-    attr_accessor :error # type: string
+    attr_accessor :vertices, :edges, :error # type: string # type: string # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -105,8 +95,7 @@ module LSP
   #   data: string;
   # }
   class PuppetfileDependencyResponse < LSPBase
-    attr_accessor :dependencies # type: string[]
-    attr_accessor :error # type: string
+    attr_accessor :dependencies, :error # type: string[] # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -126,8 +115,7 @@ module LSP
   #   data: string;
   # }
   class CompileNodeGraphResponse < LSPBase
-    attr_accessor :dotContent # type: string
-    attr_accessor :error # type: string
+    attr_accessor :dotContent, :error # type: string # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -147,8 +135,7 @@ module LSP
   #   alwaysReturnContent: boolean;
   # }
   class PuppetFixDiagnosticErrorsRequest < LSPBase
-    attr_accessor :documentUri # type: string
-    attr_accessor :alwaysReturnContent # type: boolean
+    attr_accessor :documentUri, :alwaysReturnContent # type: string # type: boolean
 
     def from_h!(value)
       value = {} if value.nil?
@@ -164,9 +151,7 @@ module LSP
   #   newContent?: string;
   # }
   class PuppetFixDiagnosticErrorsResponse < LSPBase
-    attr_accessor :documentUri # type: string
-    attr_accessor :fixesApplied # type: number
-    attr_accessor :newContent # type: string
+    attr_accessor :documentUri, :fixesApplied, :newContent # type: string # type: number # type: string
 
     def initialize(initial_hash = nil)
       super

--- a/lib/lsp/lsp_protocol.rb
+++ b/lib/lsp/lsp_protocol.rb
@@ -25,9 +25,7 @@ module LSP
   #     registerOptions?: any;
   # }
   class Registration < LSPBase
-    attr_accessor :id # type: string
-    attr_accessor :method__lsp # type: string
-    attr_accessor :registerOptions # type: any
+    attr_accessor :id, :method__lsp, :registerOptions # type: string # type: string # type: any
 
     def initialize(initial_hash = nil)
       super
@@ -68,8 +66,7 @@ module LSP
   #     method: string;
   # }
   class Unregistration < LSPBase
-    attr_accessor :id # type: string
-    attr_accessor :method__lsp # type: string
+    attr_accessor :id, :method__lsp # type: string # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -146,8 +143,7 @@ module LSP
   #     position: Position;
   # }
   class TextDocumentPositionParams < LSPBase
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :position # type: Position
+    attr_accessor :textDocument, :position # type: TextDocumentIdentifier # type: Position
 
     def from_h!(value)
       value = {} if value.nil?
@@ -261,8 +257,8 @@ module LSP
   #     [custom: string]: any;
   # }
   class InitializeResult < LSPBase
-    attr_accessor :capabilities # type: ServerCapabilities<T>
-    attr_accessor :serverInfo # type: {
+    attr_accessor :capabilities, :serverInfo # type: ServerCapabilities<T> # type: {
+
     #        /**
     #         * The name of the server as defined by the server.
     #         */
@@ -381,8 +377,7 @@ module LSP
   #     message: string;
   # }
   class ShowMessageParams < LSPBase
-    attr_accessor :type # type: MessageType
-    attr_accessor :message # type: string
+    attr_accessor :type, :message # type: MessageType # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -423,9 +418,7 @@ module LSP
   #     actions?: MessageActionItem[];
   # }
   class ShowMessageRequestParams < LSPBase
-    attr_accessor :type # type: MessageType
-    attr_accessor :message # type: string
-    attr_accessor :actions # type: MessageActionItem[]
+    attr_accessor :type, :message, :actions # type: MessageType # type: string # type: MessageActionItem[]
 
     def initialize(initial_hash = nil)
       super
@@ -452,8 +445,7 @@ module LSP
   #     message: string;
   # }
   class LogMessageParams < LSPBase
-    attr_accessor :type # type: MessageType
-    attr_accessor :message # type: string
+    attr_accessor :type, :message # type: MessageType # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -484,10 +476,7 @@ module LSP
   #     didSave?: boolean;
   # }
   class TextDocumentSyncClientCapabilities < LSPBase
-    attr_accessor :dynamicRegistration # type: boolean
-    attr_accessor :willSave # type: boolean
-    attr_accessor :willSaveWaitUntil # type: boolean
-    attr_accessor :didSave # type: boolean
+    attr_accessor :dynamicRegistration, :willSave, :willSaveWaitUntil, :didSave # type: boolean # type: boolean # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -532,11 +521,7 @@ module LSP
   #     save?: SaveOptions;
   # }
   class TextDocumentSyncOptions < LSPBase
-    attr_accessor :openClose # type: boolean
-    attr_accessor :change # type: TextDocumentSyncKind
-    attr_accessor :willSave # type: boolean
-    attr_accessor :willSaveWaitUntil # type: boolean
-    attr_accessor :save # type: SaveOptions
+    attr_accessor :openClose, :change, :willSave, :willSaveWaitUntil, :save # type: boolean # type: TextDocumentSyncKind # type: boolean # type: boolean # type: SaveOptions
 
     def initialize(initial_hash = nil)
       super
@@ -593,8 +578,7 @@ module LSP
   #     contentChanges: TextDocumentContentChangeEvent[];
   # }
   class DidChangeTextDocumentParams < LSPBase
-    attr_accessor :textDocument # type: VersionedTextDocumentIdentifier
-    attr_accessor :contentChanges # type: TextDocumentContentChangeEvent[]
+    attr_accessor :textDocument, :contentChanges # type: VersionedTextDocumentIdentifier # type: TextDocumentContentChangeEvent[]
 
     def from_h!(value)
       value = {} if value.nil?
@@ -611,8 +595,7 @@ module LSP
   #     syncKind: TextDocumentSyncKind;
   # }
   class TextDocumentChangeRegistrationOptions < LSPBase
-    attr_accessor :syncKind # type: TextDocumentSyncKind
-    attr_accessor :documentSelector # type: DocumentSelector | null
+    attr_accessor :syncKind, :documentSelector # type: TextDocumentSyncKind # type: DocumentSelector | null
 
     def from_h!(value)
       value = {} if value.nil?
@@ -650,8 +633,7 @@ module LSP
   #     text?: string;
   # }
   class DidSaveTextDocumentParams < LSPBase
-    attr_accessor :textDocument # type: VersionedTextDocumentIdentifier
-    attr_accessor :text # type: string
+    attr_accessor :textDocument, :text # type: VersionedTextDocumentIdentifier # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -669,8 +651,7 @@ module LSP
   # export interface TextDocumentSaveRegistrationOptions extends TextDocumentRegistrationOptions, SaveOptions {
   # }
   class TextDocumentSaveRegistrationOptions < LSPBase
-    attr_accessor :documentSelector # type: DocumentSelector | null
-    attr_accessor :includeText # type: boolean
+    attr_accessor :documentSelector, :includeText # type: DocumentSelector | null # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -696,8 +677,7 @@ module LSP
   #     reason: TextDocumentSaveReason;
   # }
   class WillSaveTextDocumentParams < LSPBase
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :reason # type: TextDocumentSaveReason
+    attr_accessor :textDocument, :reason # type: TextDocumentIdentifier # type: TextDocumentSaveReason
 
     def from_h!(value)
       value = {} if value.nil?
@@ -757,8 +737,7 @@ module LSP
   #     type: FileChangeType;
   # }
   class FileEvent < LSPBase
-    attr_accessor :uri # type: DocumentUri
-    attr_accessor :type # type: FileChangeType
+    attr_accessor :uri, :type # type: DocumentUri # type: FileChangeType
 
     def from_h!(value)
       value = {} if value.nil?
@@ -803,8 +782,7 @@ module LSP
   #     kind?: number;
   # }
   class FileSystemWatcher < LSPBase
-    attr_accessor :globPattern # type: string
-    attr_accessor :kind # type: number
+    attr_accessor :globPattern, :kind # type: string # type: number
 
     def initialize(initial_hash = nil)
       super
@@ -845,8 +823,7 @@ module LSP
   #     versionSupport?: boolean;
   # }
   class PublishDiagnosticsClientCapabilities < LSPBase
-    attr_accessor :relatedInformation # type: boolean
-    attr_accessor :tagSupport # type: {
+    attr_accessor :relatedInformation, :tagSupport # type: boolean # type: {
     #        /**
     #         * The tags supported by the client.
     #         */
@@ -885,9 +862,7 @@ module LSP
   #     diagnostics: Diagnostic[];
   # }
   class PublishDiagnosticsParams < LSPBase
-    attr_accessor :uri # type: DocumentUri
-    attr_accessor :version # type: number
-    attr_accessor :diagnostics # type: Diagnostic[]
+    attr_accessor :uri, :version, :diagnostics # type: DocumentUri # type: number # type: Diagnostic[]
 
     def initialize(initial_hash = nil)
       super
@@ -974,8 +949,7 @@ module LSP
   #     contextSupport?: boolean;
   # }
   class CompletionClientCapabilities < LSPBase
-    attr_accessor :dynamicRegistration # type: boolean
-    attr_accessor :completionItem # type: {
+    attr_accessor :dynamicRegistration, :completionItem # type: boolean # type: {
     #        /**
     #         * Client supports snippets as insert text.
     #         *
@@ -1059,8 +1033,7 @@ module LSP
   #     triggerCharacter?: string;
   # }
   class CompletionContext < LSPBase
-    attr_accessor :triggerKind # type: CompletionTriggerKind
-    attr_accessor :triggerCharacter # type: string
+    attr_accessor :triggerKind, :triggerCharacter # type: CompletionTriggerKind # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1083,11 +1056,7 @@ module LSP
   #     context?: CompletionContext;
   # }
   class CompletionParams < LSPBase
-    attr_accessor :context # type: CompletionContext
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :position # type: Position
-    attr_accessor :workDoneToken # type: ProgressToken
-    attr_accessor :partialResultToken # type: ProgressToken
+    attr_accessor :context, :textDocument, :position, :workDoneToken, :partialResultToken # type: CompletionContext # type: TextDocumentIdentifier # type: Position # type: ProgressToken # type: ProgressToken
 
     def initialize(initial_hash = nil)
       super
@@ -1135,10 +1104,7 @@ module LSP
   #     resolveProvider?: boolean;
   # }
   class CompletionOptions < LSPBase
-    attr_accessor :triggerCharacters # type: string[]
-    attr_accessor :allCommitCharacters # type: string[]
-    attr_accessor :resolveProvider # type: boolean
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :triggerCharacters, :allCommitCharacters, :resolveProvider, :workDoneProgress # type: string[] # type: string[] # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -1158,11 +1124,7 @@ module LSP
   # export interface CompletionRegistrationOptions extends TextDocumentRegistrationOptions, CompletionOptions {
   # }
   class CompletionRegistrationOptions < LSPBase
-    attr_accessor :documentSelector # type: DocumentSelector | null
-    attr_accessor :triggerCharacters # type: string[]
-    attr_accessor :allCommitCharacters # type: string[]
-    attr_accessor :resolveProvider # type: boolean
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :documentSelector, :triggerCharacters, :allCommitCharacters, :resolveProvider, :workDoneProgress # type: DocumentSelector | null # type: string[] # type: string[] # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -1192,8 +1154,7 @@ module LSP
   #     contentFormat?: MarkupKind[];
   # }
   class HoverClientCapabilities < LSPBase
-    attr_accessor :dynamicRegistration # type: boolean
-    attr_accessor :contentFormat # type: MarkupKind[]
+    attr_accessor :dynamicRegistration, :contentFormat # type: boolean # type: MarkupKind[]
 
     def initialize(initial_hash = nil)
       super
@@ -1228,9 +1189,7 @@ module LSP
   # export interface HoverParams extends TextDocumentPositionParams, WorkDoneProgressParams {
   # }
   class HoverParams < LSPBase
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :position # type: Position
-    attr_accessor :workDoneToken # type: ProgressToken
+    attr_accessor :textDocument, :position, :workDoneToken # type: TextDocumentIdentifier # type: Position # type: ProgressToken
 
     def initialize(initial_hash = nil)
       super
@@ -1249,8 +1208,7 @@ module LSP
   # export interface HoverRegistrationOptions extends TextDocumentRegistrationOptions, HoverOptions {
   # }
   class HoverRegistrationOptions < LSPBase
-    attr_accessor :documentSelector # type: DocumentSelector | null
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :documentSelector, :workDoneProgress # type: DocumentSelector | null # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -1304,8 +1262,7 @@ module LSP
   #     contextSupport?: boolean;
   # }
   class SignatureHelpClientCapabilities < LSPBase
-    attr_accessor :dynamicRegistration # type: boolean
-    attr_accessor :signatureInformation # type: {
+    attr_accessor :dynamicRegistration, :signatureInformation # type: boolean # type: {
     #        /**
     #         * Client supports the follow content formats for the documentation
     #         * property. The order describes the preferred format of the client.
@@ -1356,9 +1313,7 @@ module LSP
   #     retriggerCharacters?: string[];
   # }
   class SignatureHelpOptions < LSPBase
-    attr_accessor :triggerCharacters # type: string[]
-    attr_accessor :retriggerCharacters # type: string[]
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :triggerCharacters, :retriggerCharacters, :workDoneProgress # type: string[] # type: string[] # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -1401,10 +1356,7 @@ module LSP
   #     activeSignatureHelp?: SignatureHelp;
   # }
   class SignatureHelpContext < LSPBase
-    attr_accessor :triggerKind # type: SignatureHelpTriggerKind
-    attr_accessor :triggerCharacter # type: string
-    attr_accessor :isRetrigger # type: boolean
-    attr_accessor :activeSignatureHelp # type: SignatureHelp
+    attr_accessor :triggerKind, :triggerCharacter, :isRetrigger, :activeSignatureHelp # type: SignatureHelpTriggerKind # type: string # type: boolean # type: SignatureHelp
 
     def initialize(initial_hash = nil)
       super
@@ -1431,10 +1383,7 @@ module LSP
   #     context?: SignatureHelpContext;
   # }
   class SignatureHelpParams < LSPBase
-    attr_accessor :context # type: SignatureHelpContext
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :position # type: Position
-    attr_accessor :workDoneToken # type: ProgressToken
+    attr_accessor :context, :textDocument, :position, :workDoneToken # type: SignatureHelpContext # type: TextDocumentIdentifier # type: Position # type: ProgressToken
 
     def initialize(initial_hash = nil)
       super
@@ -1454,10 +1403,7 @@ module LSP
   # export interface SignatureHelpRegistrationOptions extends TextDocumentRegistrationOptions, SignatureHelpOptions {
   # }
   class SignatureHelpRegistrationOptions < LSPBase
-    attr_accessor :documentSelector # type: DocumentSelector | null
-    attr_accessor :triggerCharacters # type: string[]
-    attr_accessor :retriggerCharacters # type: string[]
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :documentSelector, :triggerCharacters, :retriggerCharacters, :workDoneProgress # type: DocumentSelector | null # type: string[] # type: string[] # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -1487,8 +1433,7 @@ module LSP
   #     linkSupport?: boolean;
   # }
   class DefinitionClientCapabilities < LSPBase
-    attr_accessor :dynamicRegistration # type: boolean
-    attr_accessor :linkSupport # type: boolean
+    attr_accessor :dynamicRegistration, :linkSupport # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -1523,10 +1468,7 @@ module LSP
   # export interface DefinitionParams extends TextDocumentPositionParams, WorkDoneProgressParams, PartialResultParams {
   # }
   class DefinitionParams < LSPBase
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :position # type: Position
-    attr_accessor :workDoneToken # type: ProgressToken
-    attr_accessor :partialResultToken # type: ProgressToken
+    attr_accessor :textDocument, :position, :workDoneToken, :partialResultToken # type: TextDocumentIdentifier # type: Position # type: ProgressToken # type: ProgressToken
 
     def initialize(initial_hash = nil)
       super
@@ -1546,8 +1488,7 @@ module LSP
   # export interface DefinitionRegistrationOptions extends TextDocumentRegistrationOptions, DefinitionOptions {
   # }
   class DefinitionRegistrationOptions < LSPBase
-    attr_accessor :documentSelector # type: DocumentSelector | null
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :documentSelector, :workDoneProgress # type: DocumentSelector | null # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -1587,11 +1528,7 @@ module LSP
   #     context: ReferenceContext;
   # }
   class ReferenceParams < LSPBase
-    attr_accessor :context # type: ReferenceContext
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :position # type: Position
-    attr_accessor :workDoneToken # type: ProgressToken
-    attr_accessor :partialResultToken # type: ProgressToken
+    attr_accessor :context, :textDocument, :position, :workDoneToken, :partialResultToken # type: ReferenceContext # type: TextDocumentIdentifier # type: Position # type: ProgressToken # type: ProgressToken
 
     def initialize(initial_hash = nil)
       super
@@ -1629,8 +1566,7 @@ module LSP
   # export interface ReferenceRegistrationOptions extends TextDocumentRegistrationOptions, ReferenceOptions {
   # }
   class ReferenceRegistrationOptions < LSPBase
-    attr_accessor :documentSelector # type: DocumentSelector | null
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :documentSelector, :workDoneProgress # type: DocumentSelector | null # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -1669,10 +1605,7 @@ module LSP
   # export interface DocumentHighlightParams extends TextDocumentPositionParams, WorkDoneProgressParams, PartialResultParams {
   # }
   class DocumentHighlightParams < LSPBase
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :position # type: Position
-    attr_accessor :workDoneToken # type: ProgressToken
-    attr_accessor :partialResultToken # type: ProgressToken
+    attr_accessor :textDocument, :position, :workDoneToken, :partialResultToken # type: TextDocumentIdentifier # type: Position # type: ProgressToken # type: ProgressToken
 
     def initialize(initial_hash = nil)
       super
@@ -1709,8 +1642,7 @@ module LSP
   # export interface DocumentHighlightRegistrationOptions extends TextDocumentRegistrationOptions, DocumentHighlightOptions {
   # }
   class DocumentHighlightRegistrationOptions < LSPBase
-    attr_accessor :documentSelector # type: DocumentSelector | null
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :documentSelector, :workDoneProgress # type: DocumentSelector | null # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -1752,8 +1684,7 @@ module LSP
   #     hierarchicalDocumentSymbolSupport?: boolean;
   # }
   class DocumentSymbolClientCapabilities < LSPBase
-    attr_accessor :dynamicRegistration # type: boolean
-    attr_accessor :symbolKind # type: {
+    attr_accessor :dynamicRegistration, :symbolKind # type: boolean # type: {
     #        /**
     #         * The symbol kind values the client supports. When this
     #         * property exists the client also guarantees that it will
@@ -1789,9 +1720,7 @@ module LSP
   #     textDocument: TextDocumentIdentifier;
   # }
   class DocumentSymbolParams < LSPBase
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :workDoneToken # type: ProgressToken
-    attr_accessor :partialResultToken # type: ProgressToken
+    attr_accessor :textDocument, :workDoneToken, :partialResultToken # type: TextDocumentIdentifier # type: ProgressToken # type: ProgressToken
 
     def initialize(initial_hash = nil)
       super
@@ -1827,8 +1756,7 @@ module LSP
   # export interface DocumentSymbolRegistrationOptions extends TextDocumentRegistrationOptions, DocumentSymbolOptions {
   # }
   class DocumentSymbolRegistrationOptions < LSPBase
-    attr_accessor :documentSelector # type: DocumentSelector | null
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :documentSelector, :workDoneProgress # type: DocumentSelector | null # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -1876,8 +1804,7 @@ module LSP
   #     isPreferredSupport?: boolean;
   # }
   class CodeActionClientCapabilities < LSPBase
-    attr_accessor :dynamicRegistration # type: boolean
-    attr_accessor :codeActionLiteralSupport # type: {
+    attr_accessor :dynamicRegistration, :codeActionLiteralSupport # type: boolean # type: {
     #        /**
     #         * The code action kind is support with the following value
     #         * set.
@@ -1923,11 +1850,7 @@ module LSP
   #     context: CodeActionContext;
   # }
   class CodeActionParams < LSPBase
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :range # type: Range
-    attr_accessor :context # type: CodeActionContext
-    attr_accessor :workDoneToken # type: ProgressToken
-    attr_accessor :partialResultToken # type: ProgressToken
+    attr_accessor :textDocument, :range, :context, :workDoneToken, :partialResultToken # type: TextDocumentIdentifier # type: Range # type: CodeActionContext # type: ProgressToken # type: ProgressToken
 
     def initialize(initial_hash = nil)
       super
@@ -1955,8 +1878,7 @@ module LSP
   #     codeActionKinds?: CodeActionKind[];
   # }
   class CodeActionOptions < LSPBase
-    attr_accessor :codeActionKinds # type: CodeActionKind[]
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :codeActionKinds, :workDoneProgress # type: CodeActionKind[] # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -1974,9 +1896,7 @@ module LSP
   # export interface CodeActionRegistrationOptions extends TextDocumentRegistrationOptions, CodeActionOptions {
   # }
   class CodeActionRegistrationOptions < LSPBase
-    attr_accessor :documentSelector # type: DocumentSelector | null
-    attr_accessor :codeActionKinds # type: CodeActionKind[]
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :documentSelector, :codeActionKinds, :workDoneProgress # type: DocumentSelector | null # type: CodeActionKind[] # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -2015,8 +1935,8 @@ module LSP
   #     };
   # }
   class WorkspaceSymbolClientCapabilities < LSPBase
-    attr_accessor :dynamicRegistration # type: boolean
-    attr_accessor :symbolKind # type: {
+    attr_accessor :dynamicRegistration, :symbolKind # type: boolean # type: {
+
     #        /**
     #         * The symbol kind values the client supports. When this
     #         * property exists the client also guarantees that it will
@@ -2051,9 +1971,7 @@ module LSP
   #     query: string;
   # }
   class WorkspaceSymbolParams < LSPBase
-    attr_accessor :query # type: string
-    attr_accessor :workDoneToken # type: ProgressToken
-    attr_accessor :partialResultToken # type: ProgressToken
+    attr_accessor :query, :workDoneToken, :partialResultToken # type: string # type: ProgressToken # type: ProgressToken
 
     def initialize(initial_hash = nil)
       super
@@ -2131,9 +2049,7 @@ module LSP
   #     textDocument: TextDocumentIdentifier;
   # }
   class CodeLensParams < LSPBase
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :workDoneToken # type: ProgressToken
-    attr_accessor :partialResultToken # type: ProgressToken
+    attr_accessor :textDocument, :workDoneToken, :partialResultToken # type: TextDocumentIdentifier # type: ProgressToken # type: ProgressToken
 
     def initialize(initial_hash = nil)
       super
@@ -2156,8 +2072,7 @@ module LSP
   #     resolveProvider?: boolean;
   # }
   class CodeLensOptions < LSPBase
-    attr_accessor :resolveProvider # type: boolean
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :resolveProvider, :workDoneProgress # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -2175,9 +2090,7 @@ module LSP
   # export interface CodeLensRegistrationOptions extends TextDocumentRegistrationOptions, CodeLensOptions {
   # }
   class CodeLensRegistrationOptions < LSPBase
-    attr_accessor :documentSelector # type: DocumentSelector | null
-    attr_accessor :resolveProvider # type: boolean
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :documentSelector, :resolveProvider, :workDoneProgress # type: DocumentSelector | null # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -2206,8 +2119,7 @@ module LSP
   #     tooltipSupport?: boolean;
   # }
   class DocumentLinkClientCapabilities < LSPBase
-    attr_accessor :dynamicRegistration # type: boolean
-    attr_accessor :tooltipSupport # type: boolean
+    attr_accessor :dynamicRegistration, :tooltipSupport # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -2229,9 +2141,7 @@ module LSP
   #     textDocument: TextDocumentIdentifier;
   # }
   class DocumentLinkParams < LSPBase
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :workDoneToken # type: ProgressToken
-    attr_accessor :partialResultToken # type: ProgressToken
+    attr_accessor :textDocument, :workDoneToken, :partialResultToken # type: TextDocumentIdentifier # type: ProgressToken # type: ProgressToken
 
     def initialize(initial_hash = nil)
       super
@@ -2254,8 +2164,7 @@ module LSP
   #     resolveProvider?: boolean;
   # }
   class DocumentLinkOptions < LSPBase
-    attr_accessor :resolveProvider # type: boolean
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :resolveProvider, :workDoneProgress # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -2273,9 +2182,7 @@ module LSP
   # export interface DocumentLinkRegistrationOptions extends TextDocumentRegistrationOptions, DocumentLinkOptions {
   # }
   class DocumentLinkRegistrationOptions < LSPBase
-    attr_accessor :documentSelector # type: DocumentSelector | null
-    attr_accessor :resolveProvider # type: boolean
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :documentSelector, :resolveProvider, :workDoneProgress # type: DocumentSelector | null # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -2323,9 +2230,7 @@ module LSP
   #     options: FormattingOptions;
   # }
   class DocumentFormattingParams < LSPBase
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :options # type: FormattingOptions
-    attr_accessor :workDoneToken # type: ProgressToken
+    attr_accessor :textDocument, :options, :workDoneToken # type: TextDocumentIdentifier # type: FormattingOptions # type: ProgressToken
 
     def initialize(initial_hash = nil)
       super
@@ -2361,8 +2266,7 @@ module LSP
   # export interface DocumentFormattingRegistrationOptions extends TextDocumentRegistrationOptions, DocumentFormattingOptions {
   # }
   class DocumentFormattingRegistrationOptions < LSPBase
-    attr_accessor :documentSelector # type: DocumentSelector | null
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :documentSelector, :workDoneProgress # type: DocumentSelector | null # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -2413,10 +2317,7 @@ module LSP
   #     options: FormattingOptions;
   # }
   class DocumentRangeFormattingParams < LSPBase
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :range # type: Range
-    attr_accessor :options # type: FormattingOptions
-    attr_accessor :workDoneToken # type: ProgressToken
+    attr_accessor :textDocument, :range, :options, :workDoneToken # type: TextDocumentIdentifier # type: Range # type: FormattingOptions # type: ProgressToken
 
     def initialize(initial_hash = nil)
       super
@@ -2453,8 +2354,7 @@ module LSP
   # export interface DocumentRangeFormattingRegistrationOptions extends TextDocumentRegistrationOptions, DocumentRangeFormattingOptions {
   # }
   class DocumentRangeFormattingRegistrationOptions < LSPBase
-    attr_accessor :documentSelector # type: DocumentSelector | null
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :documentSelector, :workDoneProgress # type: DocumentSelector | null # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -2509,10 +2409,7 @@ module LSP
   #     options: FormattingOptions;
   # }
   class DocumentOnTypeFormattingParams < LSPBase
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :position # type: Position
-    attr_accessor :ch # type: string
-    attr_accessor :options # type: FormattingOptions
+    attr_accessor :textDocument, :position, :ch, :options # type: TextDocumentIdentifier # type: Position # type: string # type: FormattingOptions
 
     def from_h!(value)
       value = {} if value.nil?
@@ -2535,8 +2432,7 @@ module LSP
   #     moreTriggerCharacter?: string[];
   # }
   class DocumentOnTypeFormattingOptions < LSPBase
-    attr_accessor :firstTriggerCharacter # type: string
-    attr_accessor :moreTriggerCharacter # type: string[]
+    attr_accessor :firstTriggerCharacter, :moreTriggerCharacter # type: string # type: string[]
 
     def initialize(initial_hash = nil)
       super
@@ -2554,9 +2450,7 @@ module LSP
   # export interface DocumentOnTypeFormattingRegistrationOptions extends TextDocumentRegistrationOptions, DocumentOnTypeFormattingOptions {
   # }
   class DocumentOnTypeFormattingRegistrationOptions < LSPBase
-    attr_accessor :documentSelector # type: DocumentSelector | null
-    attr_accessor :firstTriggerCharacter # type: string
-    attr_accessor :moreTriggerCharacter # type: string[]
+    attr_accessor :documentSelector, :firstTriggerCharacter, :moreTriggerCharacter # type: DocumentSelector | null # type: string # type: string[]
 
     def initialize(initial_hash = nil)
       super
@@ -2586,8 +2480,7 @@ module LSP
   #     prepareSupport?: boolean;
   # }
   class RenameClientCapabilities < LSPBase
-    attr_accessor :dynamicRegistration # type: boolean
-    attr_accessor :prepareSupport # type: boolean
+    attr_accessor :dynamicRegistration, :prepareSupport # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -2619,10 +2512,7 @@ module LSP
   #     newName: string;
   # }
   class RenameParams < LSPBase
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :position # type: Position
-    attr_accessor :newName # type: string
-    attr_accessor :workDoneToken # type: ProgressToken
+    attr_accessor :textDocument, :position, :newName, :workDoneToken # type: TextDocumentIdentifier # type: Position # type: string # type: ProgressToken
 
     def initialize(initial_hash = nil)
       super
@@ -2648,8 +2538,7 @@ module LSP
   #     prepareProvider?: boolean;
   # }
   class RenameOptions < LSPBase
-    attr_accessor :prepareProvider # type: boolean
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :prepareProvider, :workDoneProgress # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -2667,9 +2556,7 @@ module LSP
   # export interface RenameRegistrationOptions extends TextDocumentRegistrationOptions, RenameOptions {
   # }
   class RenameRegistrationOptions < LSPBase
-    attr_accessor :documentSelector # type: DocumentSelector | null
-    attr_accessor :prepareProvider # type: boolean
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :documentSelector, :prepareProvider, :workDoneProgress # type: DocumentSelector | null # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -2688,9 +2575,7 @@ module LSP
   # export interface PrepareRenameParams extends TextDocumentPositionParams, WorkDoneProgressParams {
   # }
   class PrepareRenameParams < LSPBase
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :position # type: Position
-    attr_accessor :workDoneToken # type: ProgressToken
+    attr_accessor :textDocument, :position, :workDoneToken # type: TextDocumentIdentifier # type: Position # type: ProgressToken
 
     def initialize(initial_hash = nil)
       super
@@ -2738,9 +2623,7 @@ module LSP
   #     arguments?: any[];
   # }
   class ExecuteCommandParams < LSPBase
-    attr_accessor :command # type: string
-    attr_accessor :arguments # type: any[]
-    attr_accessor :workDoneToken # type: ProgressToken
+    attr_accessor :command, :arguments, :workDoneToken # type: string # type: any[] # type: ProgressToken
 
     def initialize(initial_hash = nil)
       super
@@ -2763,8 +2646,7 @@ module LSP
   #     commands: string[];
   # }
   class ExecuteCommandOptions < LSPBase
-    attr_accessor :commands # type: string[]
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :commands, :workDoneProgress # type: string[] # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -2782,8 +2664,7 @@ module LSP
   # export interface ExecuteCommandRegistrationOptions extends ExecuteCommandOptions {
   # }
   class ExecuteCommandRegistrationOptions < LSPBase
-    attr_accessor :commands # type: string[]
-    attr_accessor :workDoneProgress # type: boolean
+    attr_accessor :commands, :workDoneProgress # type: string[] # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -2819,9 +2700,7 @@ module LSP
   #     failureHandling?: FailureHandlingKind;
   # }
   class WorkspaceEditClientCapabilities < LSPBase
-    attr_accessor :documentChanges # type: boolean
-    attr_accessor :resourceOperations # type: ResourceOperationKind[]
-    attr_accessor :failureHandling # type: FailureHandlingKind
+    attr_accessor :documentChanges, :resourceOperations, :failureHandling # type: boolean # type: ResourceOperationKind[] # type: FailureHandlingKind
 
     def initialize(initial_hash = nil)
       super
@@ -2850,8 +2729,7 @@ module LSP
   #     edit: WorkspaceEdit;
   # }
   class ApplyWorkspaceEditParams < LSPBase
-    attr_accessor :label # type: string
-    attr_accessor :edit # type: WorkspaceEdit
+    attr_accessor :label, :edit # type: string # type: WorkspaceEdit
 
     def initialize(initial_hash = nil)
       super
@@ -2885,9 +2763,7 @@ module LSP
   #     failedChange?: number;
   # }
   class ApplyWorkspaceEditResponse < LSPBase
-    attr_accessor :applied # type: boolean
-    attr_accessor :failureReason # type: string
-    attr_accessor :failedChange # type: number
+    attr_accessor :applied, :failureReason, :failedChange # type: boolean # type: string # type: number
 
     def initialize(initial_hash = nil)
       super

--- a/lib/lsp/lsp_protocol_callhierarchy.proposed.rb
+++ b/lib/lsp/lsp_protocol_callhierarchy.proposed.rb
@@ -41,13 +41,7 @@ module LSP
   #     selectionRange: Range;
   # }
   class CallHierarchyItem < LSPBase
-    attr_accessor :name # type: string
-    attr_accessor :kind # type: SymbolKind
-    attr_accessor :tags # type: SymbolTag[]
-    attr_accessor :detail # type: string
-    attr_accessor :uri # type: DocumentUri
-    attr_accessor :range # type: Range
-    attr_accessor :selectionRange # type: Range
+    attr_accessor :name, :kind, :tags, :detail, :uri, :range, :selectionRange # type: string # type: SymbolKind # type: SymbolTag[] # type: string # type: DocumentUri # type: Range # type: Range
 
     def initialize(initial_hash = nil)
       super
@@ -79,8 +73,7 @@ module LSP
   #     fromRanges: Range[];
   # }
   class CallHierarchyIncomingCall < LSPBase
-    attr_accessor :from # type: CallHierarchyItem
-    attr_accessor :fromRanges # type: Range[]
+    attr_accessor :from, :fromRanges # type: CallHierarchyItem # type: Range[]
 
     def from_h!(value)
       value = {} if value.nil?
@@ -103,8 +96,7 @@ module LSP
   #     fromRanges: Range[];
   # }
   class CallHierarchyOutgoingCall < LSPBase
-    attr_accessor :to # type: CallHierarchyItem
-    attr_accessor :fromRanges # type: Range[]
+    attr_accessor :to, :fromRanges # type: CallHierarchyItem # type: Range[]
 
     def from_h!(value)
       value = {} if value.nil?
@@ -136,6 +128,7 @@ module LSP
   # }
   class CallHierarchyClientCapabilities < LSPBase
     attr_accessor :textDocument # type: {
+
     #        /**
     #         * Capabilities specific to the `textDocument/callHierarchy`.
     #         *

--- a/lib/lsp/lsp_protocol_colorprovider.rb
+++ b/lib/lsp/lsp_protocol_colorprovider.rb
@@ -83,9 +83,7 @@ module LSP
   #     range: Range;
   # }
   class ColorPresentationParams < LSPBase
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :color # type: Color
-    attr_accessor :range # type: Range
+    attr_accessor :textDocument, :color, :range # type: TextDocumentIdentifier # type: Color # type: Range
 
     def from_h!(value)
       value = {} if value.nil?

--- a/lib/lsp/lsp_protocol_configuration.rb
+++ b/lib/lsp/lsp_protocol_configuration.rb
@@ -22,6 +22,7 @@ module LSP
   # }
   class ConfigurationClientCapabilities < LSPBase
     attr_accessor :workspace # type: {
+
     #        /**
     #        * The client supports `workspace/configuration` requests.
     #        */
@@ -51,8 +52,7 @@ module LSP
   #     section?: string;
   # }
   class ConfigurationItem < LSPBase
-    attr_accessor :scopeUri # type: string
-    attr_accessor :section # type: string
+    attr_accessor :scopeUri, :section # type: string # type: string
 
     def initialize(initial_hash = nil)
       super

--- a/lib/lsp/lsp_protocol_declaration.rb
+++ b/lib/lsp/lsp_protocol_declaration.rb
@@ -22,8 +22,7 @@ module LSP
   #     linkSupport?: boolean;
   # }
   class DeclarationClientCapabilities < LSPBase
-    attr_accessor :dynamicRegistration # type: boolean
-    attr_accessor :linkSupport # type: boolean
+    attr_accessor :dynamicRegistration, :linkSupport # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super

--- a/lib/lsp/lsp_protocol_foldingrange.rb
+++ b/lib/lsp/lsp_protocol_foldingrange.rb
@@ -28,9 +28,7 @@ module LSP
   #     lineFoldingOnly?: boolean;
   # }
   class FoldingRangeClientCapabilities < LSPBase
-    attr_accessor :dynamicRegistration # type: boolean
-    attr_accessor :rangeLimit # type: number
-    attr_accessor :lineFoldingOnly # type: boolean
+    attr_accessor :dynamicRegistration, :rangeLimit, :lineFoldingOnly # type: boolean # type: number # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -91,11 +89,7 @@ module LSP
   #     kind?: string;
   # }
   class FoldingRange < LSPBase
-    attr_accessor :startLine # type: number
-    attr_accessor :startCharacter # type: number
-    attr_accessor :endLine # type: number
-    attr_accessor :endCharacter # type: number
-    attr_accessor :kind # type: string
+    attr_accessor :startLine, :startCharacter, :endLine, :endCharacter, :kind # type: number # type: number # type: number # type: number # type: string
 
     def initialize(initial_hash = nil)
       super

--- a/lib/lsp/lsp_protocol_implementation.rb
+++ b/lib/lsp/lsp_protocol_implementation.rb
@@ -24,8 +24,7 @@ module LSP
   #     linkSupport?: boolean;
   # }
   class ImplementationClientCapabilities < LSPBase
-    attr_accessor :dynamicRegistration # type: boolean
-    attr_accessor :linkSupport # type: boolean
+    attr_accessor :dynamicRegistration, :linkSupport # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super

--- a/lib/lsp/lsp_protocol_progress.rb
+++ b/lib/lsp/lsp_protocol_progress.rb
@@ -25,6 +25,7 @@ module LSP
   # }
   class WorkDoneProgressClientCapabilities < LSPBase
     attr_accessor :window # type: {
+
     #        /**
     #         * Whether client supports handling progress notifications. If set servers are allowed to
     #         * report in `workDoneProgress` property in the request specific server capabilities.
@@ -80,11 +81,7 @@ module LSP
   #     percentage?: number;
   # }
   class WorkDoneProgressBegin < LSPBase
-    attr_accessor :kind # type: string with value 'begin'
-    attr_accessor :title # type: string
-    attr_accessor :cancellable # type: boolean
-    attr_accessor :message # type: string
-    attr_accessor :percentage # type: number
+    attr_accessor :kind, :title, :cancellable, :message, :percentage # type: string with value 'begin' # type: string # type: boolean # type: string # type: number
 
     def initialize(initial_hash = nil)
       super
@@ -131,10 +128,7 @@ module LSP
   #     percentage?: number;
   # }
   class WorkDoneProgressReport < LSPBase
-    attr_accessor :kind # type: string with value 'report'
-    attr_accessor :cancellable # type: boolean
-    attr_accessor :message # type: string
-    attr_accessor :percentage # type: number
+    attr_accessor :kind, :cancellable, :message, :percentage # type: string with value 'report' # type: boolean # type: string # type: number
 
     def initialize(initial_hash = nil)
       super
@@ -160,8 +154,7 @@ module LSP
   #     message?: string;
   # }
   class WorkDoneProgressEnd < LSPBase
-    attr_accessor :kind # type: string with value 'end'
-    attr_accessor :message # type: string
+    attr_accessor :kind, :message # type: string with value 'end' # type: string
 
     def initialize(initial_hash = nil)
       super

--- a/lib/lsp/lsp_protocol_selectionrange.rb
+++ b/lib/lsp/lsp_protocol_selectionrange.rb
@@ -63,8 +63,7 @@ module LSP
   #     positions: Position[];
   # }
   class SelectionRangeParams < LSPBase
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :positions # type: Position[]
+    attr_accessor :textDocument, :positions # type: TextDocumentIdentifier # type: Position[]
 
     def from_h!(value)
       value = {} if value.nil?

--- a/lib/lsp/lsp_protocol_sematictokens.proposed.rb
+++ b/lib/lsp/lsp_protocol_sematictokens.proposed.rb
@@ -20,8 +20,7 @@ module LSP
   #     tokenModifiers: string[];
   # }
   class SemanticTokensLegend < LSPBase
-    attr_accessor :tokenTypes # type: string[]
-    attr_accessor :tokenModifiers # type: string[]
+    attr_accessor :tokenTypes, :tokenModifiers # type: string[] # type: string[]
 
     def from_h!(value)
       value = {} if value.nil?
@@ -47,8 +46,7 @@ module LSP
   #     data: number[];
   # }
   class SemanticTokens < LSPBase
-    attr_accessor :resultId # type: string
-    attr_accessor :data # type: number[]
+    attr_accessor :resultId, :data # type: string # type: number[]
 
     def initialize(initial_hash = nil)
       super
@@ -82,9 +80,7 @@ module LSP
   #     data?: number[];
   # }
   class SemanticTokensEdit < LSPBase
-    attr_accessor :start # type: number
-    attr_accessor :deleteCount # type: number
-    attr_accessor :data # type: number[]
+    attr_accessor :start, :deleteCount, :data # type: number # type: number # type: number[]
 
     def initialize(initial_hash = nil)
       super
@@ -109,8 +105,7 @@ module LSP
   #     edits: SemanticTokensEdit[];
   # }
   class SemanticTokensEdits < LSPBase
-    attr_accessor :resultId # type: string
-    attr_accessor :edits # type: SemanticTokensEdit[]
+    attr_accessor :resultId, :edits # type: string # type: SemanticTokensEdit[]
 
     def initialize(initial_hash = nil)
       super
@@ -168,6 +163,7 @@ module LSP
   # }
   class SemanticTokensClientCapabilities < LSPBase
     attr_accessor :textDocument # type: {
+
     #        /**
     #         * Capabilities specific to the `textDocument/semanticTokens`
     #         *
@@ -224,9 +220,8 @@ module LSP
   #     };
   # }
   class SemanticTokensOptions < LSPBase
-    attr_accessor :legend # type: SemanticTokensLegend
-    attr_accessor :rangeProvider # type: boolean
-    attr_accessor :documentProvider # type: boolean | {
+    attr_accessor :legend, :rangeProvider, :documentProvider # type: SemanticTokensLegend # type: boolean # type: boolean | {
+
     #        /**
     #         * The server supports deltas for full documents.
     #         */
@@ -250,9 +245,8 @@ module LSP
   # export interface SemanticTokensRegistrationOptions extends TextDocumentRegistrationOptions, SemanticTokensOptions, StaticRegistrationOptions {
   # }
   class SemanticTokensRegistrationOptions < LSPBase
-    attr_accessor :legend # type: SemanticTokensLegend
-    attr_accessor :rangeProvider # type: boolean
-    attr_accessor :documentProvider # type: boolean | {
+    attr_accessor :legend, :rangeProvider, :documentProvider # type: SemanticTokensLegend # type: boolean # type: boolean | {
+
     #        /**
     #         * The server supports deltas for full documents.
     #         */
@@ -313,8 +307,7 @@ module LSP
   #     previousResultId: string;
   # }
   class SemanticTokensEditsParams < LSPBase
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :previousResultId # type: string
+    attr_accessor :textDocument, :previousResultId # type: TextDocumentIdentifier # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -335,8 +328,7 @@ module LSP
   #     range: Range;
   # }
   class SemanticTokensRangeParams < LSPBase
-    attr_accessor :textDocument # type: TextDocumentIdentifier
-    attr_accessor :range # type: Range
+    attr_accessor :textDocument, :range # type: TextDocumentIdentifier # type: Range
 
     def from_h!(value)
       value = {} if value.nil?

--- a/lib/lsp/lsp_protocol_typedefinition.rb
+++ b/lib/lsp/lsp_protocol_typedefinition.rb
@@ -24,8 +24,7 @@ module LSP
   #     linkSupport?: boolean;
   # }
   class TypeDefinitionClientCapabilities < LSPBase
-    attr_accessor :dynamicRegistration # type: boolean
-    attr_accessor :linkSupport # type: boolean
+    attr_accessor :dynamicRegistration, :linkSupport # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super

--- a/lib/lsp/lsp_protocol_workspacefolders.rb
+++ b/lib/lsp/lsp_protocol_workspacefolders.rb
@@ -38,6 +38,7 @@ module LSP
   # }
   class WorkspaceFoldersClientCapabilities < LSPBase
     attr_accessor :workspace # type: {
+
     #        /**
     #         * The client has support for workspace folders
     #         */
@@ -81,6 +82,7 @@ module LSP
   # }
   class WorkspaceFoldersServerCapabilities < LSPBase
     attr_accessor :workspace # type: {
+
     #        workspaceFolders?: {
     #            /**
     #             * The Server has support for workspace folders
@@ -123,8 +125,7 @@ module LSP
   #     name: string;
   # }
   class WorkspaceFolder < LSPBase
-    attr_accessor :uri # type: string
-    attr_accessor :name # type: string
+    attr_accessor :uri, :name # type: string # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -161,8 +162,7 @@ module LSP
   #     removed: WorkspaceFolder[];
   # }
   class WorkspaceFoldersChangeEvent < LSPBase
-    attr_accessor :added # type: WorkspaceFolder[]
-    attr_accessor :removed # type: WorkspaceFolder[]
+    attr_accessor :added, :removed # type: WorkspaceFolder[] # type: WorkspaceFolder[]
 
     def from_h!(value)
       value = {} if value.nil?

--- a/lib/lsp/lsp_types.rb
+++ b/lib/lsp/lsp_types.rb
@@ -28,8 +28,7 @@ module LSP
   #     character: number;
   # }
   class Position < LSPBase
-    attr_accessor :line # type: number
-    attr_accessor :character # type: number
+    attr_accessor :line, :character # type: number # type: number
 
     def from_h!(value)
       value = {} if value.nil?
@@ -50,8 +49,7 @@ module LSP
   #     end: Position;
   # }
   class Range < LSPBase
-    attr_accessor :start # type: Position
-    attr_accessor :end # type: Position
+    attr_accessor :start, :end # type: Position # type: Position
 
     def from_h!(value)
       value = {} if value.nil?
@@ -66,8 +64,7 @@ module LSP
   #     range: Range;
   # }
   class Location < LSPBase
-    attr_accessor :uri # type: DocumentUri
-    attr_accessor :range # type: Range
+    attr_accessor :uri, :range # type: DocumentUri # type: Range
 
     def from_h!(value)
       value = {} if value.nil?
@@ -102,10 +99,7 @@ module LSP
   #     targetSelectionRange: Range;
   # }
   class LocationLink < LSPBase
-    attr_accessor :originSelectionRange # type: Range
-    attr_accessor :targetUri # type: DocumentUri
-    attr_accessor :targetRange # type: Range
-    attr_accessor :targetSelectionRange # type: Range
+    attr_accessor :originSelectionRange, :targetUri, :targetRange, :targetSelectionRange # type: Range # type: DocumentUri # type: Range # type: Range
 
     def initialize(initial_hash = nil)
       super
@@ -141,10 +135,7 @@ module LSP
   #     readonly alpha: number;
   # }
   class Color < LSPBase
-    attr_accessor :red # type: number
-    attr_accessor :green # type: number
-    attr_accessor :blue # type: number
-    attr_accessor :alpha # type: number
+    attr_accessor :red, :green, :blue, :alpha # type: number # type: number # type: number # type: number
 
     def from_h!(value)
       value = {} if value.nil?
@@ -167,8 +158,7 @@ module LSP
   #     color: Color;
   # }
   class ColorInformation < LSPBase
-    attr_accessor :range # type: Range
-    attr_accessor :color # type: Color
+    attr_accessor :range, :color # type: Range # type: Color
 
     def from_h!(value)
       value = {} if value.nil?
@@ -198,9 +188,7 @@ module LSP
   #     additionalTextEdits?: TextEdit[];
   # }
   class ColorPresentation < LSPBase
-    attr_accessor :label # type: string
-    attr_accessor :textEdit # type: TextEdit
-    attr_accessor :additionalTextEdits # type: TextEdit[]
+    attr_accessor :label, :textEdit, :additionalTextEdits # type: string # type: TextEdit # type: TextEdit[]
 
     def initialize(initial_hash = nil)
       super
@@ -241,11 +229,7 @@ module LSP
   #     kind?: string;
   # }
   class FoldingRange < LSPBase
-    attr_accessor :startLine # type: number
-    attr_accessor :startCharacter # type: number
-    attr_accessor :endLine # type: number
-    attr_accessor :endCharacter # type: number
-    attr_accessor :kind # type: string
+    attr_accessor :startLine, :startCharacter, :endLine, :endCharacter, :kind # type: number # type: number # type: number # type: number # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -274,8 +258,7 @@ module LSP
   #     message: string;
   # }
   class DiagnosticRelatedInformation < LSPBase
-    attr_accessor :location # type: Location
-    attr_accessor :message # type: string
+    attr_accessor :location, :message # type: Location # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -320,13 +303,7 @@ module LSP
   #     relatedInformation?: DiagnosticRelatedInformation[];
   # }
   class Diagnostic < LSPBase
-    attr_accessor :range # type: Range
-    attr_accessor :severity # type: DiagnosticSeverity
-    attr_accessor :code # type: number | string
-    attr_accessor :source # type: string
-    attr_accessor :message # type: string
-    attr_accessor :tags # type: DiagnosticTag[]
-    attr_accessor :relatedInformation # type: DiagnosticRelatedInformation[]
+    attr_accessor :range, :severity, :code, :source, :message, :tags, :relatedInformation # type: Range # type: DiagnosticSeverity # type: number | string # type: string # type: string # type: DiagnosticTag[] # type: DiagnosticRelatedInformation[]
 
     def initialize(initial_hash = nil)
       super
@@ -362,9 +339,7 @@ module LSP
   #     arguments?: any[];
   # }
   class Command < LSPBase
-    attr_accessor :title # type: string
-    attr_accessor :command # type: string
-    attr_accessor :arguments # type: any[]
+    attr_accessor :title, :command, :arguments # type: string # type: string # type: any[]
 
     def initialize(initial_hash = nil)
       super
@@ -393,8 +368,7 @@ module LSP
   #     newText: string;
   # }
   class TextEdit < LSPBase
-    attr_accessor :range # type: Range
-    attr_accessor :newText # type: string
+    attr_accessor :range, :newText # type: Range # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -415,8 +389,7 @@ module LSP
   #     edits: TextEdit[];
   # }
   class TextDocumentEdit < LSPBase
-    attr_accessor :textDocument # type: VersionedTextDocumentIdentifier
-    attr_accessor :edits # type: TextEdit[]
+    attr_accessor :textDocument, :edits # type: VersionedTextDocumentIdentifier # type: TextEdit[]
 
     def from_h!(value)
       value = {} if value.nil?
@@ -450,8 +423,7 @@ module LSP
   #     ignoreIfExists?: boolean;
   # }
   class CreateFileOptions < LSPBase
-    attr_accessor :overwrite # type: boolean
-    attr_accessor :ignoreIfExists # type: boolean
+    attr_accessor :overwrite, :ignoreIfExists # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -481,9 +453,7 @@ module LSP
   #     options?: CreateFileOptions;
   # }
   class CreateFile < LSPBase
-    attr_accessor :kind # type: string with value 'create'
-    attr_accessor :uri # type: DocumentUri
-    attr_accessor :options # type: CreateFileOptions
+    attr_accessor :kind, :uri, :options # type: string with value 'create' # type: DocumentUri # type: CreateFileOptions
 
     def initialize(initial_hash = nil)
       super
@@ -510,8 +480,7 @@ module LSP
   #     ignoreIfExists?: boolean;
   # }
   class RenameFileOptions < LSPBase
-    attr_accessor :overwrite # type: boolean
-    attr_accessor :ignoreIfExists # type: boolean
+    attr_accessor :overwrite, :ignoreIfExists # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -545,10 +514,7 @@ module LSP
   #     options?: RenameFileOptions;
   # }
   class RenameFile < LSPBase
-    attr_accessor :kind # type: string with value 'rename'
-    attr_accessor :oldUri # type: DocumentUri
-    attr_accessor :newUri # type: DocumentUri
-    attr_accessor :options # type: RenameFileOptions
+    attr_accessor :kind, :oldUri, :newUri, :options # type: string with value 'rename' # type: DocumentUri # type: DocumentUri # type: RenameFileOptions
 
     def initialize(initial_hash = nil)
       super
@@ -576,8 +542,7 @@ module LSP
   #     ignoreIfNotExists?: boolean;
   # }
   class DeleteFileOptions < LSPBase
-    attr_accessor :recursive # type: boolean
-    attr_accessor :ignoreIfNotExists # type: boolean
+    attr_accessor :recursive, :ignoreIfNotExists # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -607,9 +572,7 @@ module LSP
   #     options?: DeleteFileOptions;
   # }
   class DeleteFile < LSPBase
-    attr_accessor :kind # type: string with value 'delete'
-    attr_accessor :uri # type: DocumentUri
-    attr_accessor :options # type: DeleteFileOptions
+    attr_accessor :kind, :uri, :options # type: string with value 'delete' # type: DocumentUri # type: DeleteFileOptions
 
     def initialize(initial_hash = nil)
       super
@@ -720,8 +683,7 @@ module LSP
   #     version: number | null;
   # }
   class VersionedTextDocumentIdentifier < LSPBase
-    attr_accessor :version # type: number | null
-    attr_accessor :uri # type: DocumentUri
+    attr_accessor :version, :uri # type: number | null # type: DocumentUri
 
     def from_h!(value)
       value = {} if value.nil?
@@ -751,10 +713,7 @@ module LSP
   #     text: string;
   # }
   class TextDocumentItem < LSPBase
-    attr_accessor :uri # type: DocumentUri
-    attr_accessor :languageId # type: string
-    attr_accessor :version # type: number
-    attr_accessor :text # type: string
+    attr_accessor :uri, :languageId, :version, :text # type: DocumentUri # type: string # type: number # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -777,8 +736,7 @@ module LSP
   #     value: string;
   # }
   class MarkupContent < LSPBase
-    attr_accessor :kind # type: MarkupKind
-    attr_accessor :value # type: string
+    attr_accessor :kind, :value # type: MarkupKind # type: string
 
     def from_h!(value)
       value = {} if value.nil?
@@ -898,22 +856,7 @@ module LSP
   #     data?: any;
   # }
   class CompletionItem < LSPBase
-    attr_accessor :label # type: string
-    attr_accessor :kind # type: CompletionItemKind
-    attr_accessor :tags # type: CompletionItemTag[]
-    attr_accessor :detail # type: string
-    attr_accessor :documentation # type: string | MarkupContent
-    attr_accessor :deprecated # type: boolean
-    attr_accessor :preselect # type: boolean
-    attr_accessor :sortText # type: string
-    attr_accessor :filterText # type: string
-    attr_accessor :insertText # type: string
-    attr_accessor :insertTextFormat # type: InsertTextFormat
-    attr_accessor :textEdit # type: TextEdit
-    attr_accessor :additionalTextEdits # type: TextEdit[]
-    attr_accessor :commitCharacters # type: string[]
-    attr_accessor :command # type: Command
-    attr_accessor :data # type: any
+    attr_accessor :label, :kind, :tags, :detail, :documentation, :deprecated, :preselect, :sortText, :filterText, :insertText, :insertTextFormat, :textEdit, :additionalTextEdits, :commitCharacters, :command, :data # type: string # type: CompletionItemKind # type: CompletionItemTag[] # type: string # type: string | MarkupContent # type: boolean # type: boolean # type: string # type: string # type: string # type: InsertTextFormat # type: TextEdit # type: TextEdit[] # type: string[] # type: Command # type: any
 
     def initialize(initial_hash = nil)
       super
@@ -953,8 +896,7 @@ module LSP
   #     items: CompletionItem[];
   # }
   class CompletionList < LSPBase
-    attr_accessor :isIncomplete # type: boolean
-    attr_accessor :items # type: CompletionItem[]
+    attr_accessor :isIncomplete, :items # type: boolean # type: CompletionItem[]
 
     def from_h!(value)
       value = {} if value.nil?
@@ -975,8 +917,7 @@ module LSP
   #     range?: Range;
   # }
   class Hover < LSPBase
-    attr_accessor :contents # type: MarkupContent | MarkedString | MarkedString[]
-    attr_accessor :range # type: Range
+    attr_accessor :contents, :range # type: MarkupContent | MarkedString | MarkedString[] # type: Range
 
     def initialize(initial_hash = nil)
       super
@@ -1010,8 +951,7 @@ module LSP
   #     documentation?: string | MarkupContent;
   # }
   class ParameterInformation < LSPBase
-    attr_accessor :label # type: string | [number, number]
-    attr_accessor :documentation # type: string | MarkupContent
+    attr_accessor :label, :documentation # type: string | [number, number] # type: string | MarkupContent
 
     def initialize(initial_hash = nil)
       super
@@ -1043,9 +983,7 @@ module LSP
   #     parameters?: ParameterInformation[];
   # }
   class SignatureInformation < LSPBase
-    attr_accessor :label # type: string
-    attr_accessor :documentation # type: string | MarkupContent
-    attr_accessor :parameters # type: ParameterInformation[]
+    attr_accessor :label, :documentation, :parameters # type: string # type: string | MarkupContent # type: ParameterInformation[]
 
     def initialize(initial_hash = nil)
       super
@@ -1078,9 +1016,7 @@ module LSP
   #     activeParameter: number | null;
   # }
   class SignatureHelp < LSPBase
-    attr_accessor :signatures # type: SignatureInformation[]
-    attr_accessor :activeSignature # type: number | null
-    attr_accessor :activeParameter # type: number | null
+    attr_accessor :signatures, :activeSignature, :activeParameter # type: SignatureInformation[] # type: number | null # type: number | null
 
     def from_h!(value)
       value = {} if value.nil?
@@ -1118,8 +1054,7 @@ module LSP
   #     kind?: DocumentHighlightKind;
   # }
   class DocumentHighlight < LSPBase
-    attr_accessor :range # type: Range
-    attr_accessor :kind # type: DocumentHighlightKind
+    attr_accessor :range, :kind # type: Range # type: DocumentHighlightKind
 
     def initialize(initial_hash = nil)
       super
@@ -1168,11 +1103,7 @@ module LSP
   #     containerName?: string;
   # }
   class SymbolInformation < LSPBase
-    attr_accessor :name # type: string
-    attr_accessor :kind # type: SymbolKind
-    attr_accessor :deprecated # type: boolean
-    attr_accessor :location # type: Location
-    attr_accessor :containerName # type: string
+    attr_accessor :name, :kind, :deprecated, :location, :containerName # type: string # type: SymbolKind # type: boolean # type: Location # type: string
 
     def initialize(initial_hash = nil)
       super
@@ -1225,13 +1156,7 @@ module LSP
   #     children?: DocumentSymbol[];
   # }
   class DocumentSymbol < LSPBase
-    attr_accessor :name # type: string
-    attr_accessor :detail # type: string
-    attr_accessor :kind # type: SymbolKind
-    attr_accessor :deprecated # type: boolean
-    attr_accessor :range # type: Range
-    attr_accessor :selectionRange # type: Range
-    attr_accessor :children # type: DocumentSymbol[]
+    attr_accessor :name, :detail, :kind, :deprecated, :range, :selectionRange, :children # type: string # type: string # type: SymbolKind # type: boolean # type: Range # type: Range # type: DocumentSymbol[]
 
     def initialize(initial_hash = nil)
       super
@@ -1269,8 +1194,7 @@ module LSP
   #     only?: CodeActionKind[];
   # }
   class CodeActionContext < LSPBase
-    attr_accessor :diagnostics # type: Diagnostic[]
-    attr_accessor :only # type: CodeActionKind[]
+    attr_accessor :diagnostics, :only # type: Diagnostic[] # type: CodeActionKind[]
 
     def initialize(initial_hash = nil)
       super
@@ -1322,12 +1246,7 @@ module LSP
   #     command?: Command;
   # }
   class CodeAction < LSPBase
-    attr_accessor :title # type: string
-    attr_accessor :kind # type: CodeActionKind
-    attr_accessor :diagnostics # type: Diagnostic[]
-    attr_accessor :isPreferred # type: boolean
-    attr_accessor :edit # type: WorkspaceEdit
-    attr_accessor :command # type: Command
+    attr_accessor :title, :kind, :diagnostics, :isPreferred, :edit, :command # type: string # type: CodeActionKind # type: Diagnostic[] # type: boolean # type: WorkspaceEdit # type: Command
 
     def initialize(initial_hash = nil)
       super
@@ -1363,9 +1282,7 @@ module LSP
   #     data?: any;
   # }
   class CodeLens < LSPBase
-    attr_accessor :range # type: Range
-    attr_accessor :command # type: Command
-    attr_accessor :data # type: any
+    attr_accessor :range, :command, :data # type: Range # type: Command # type: any
 
     def initialize(initial_hash = nil)
       super
@@ -1414,11 +1331,7 @@ module LSP
   #     [key: string]: boolean | number | string | undefined;
   # }
   class FormattingOptions < LSPBase
-    attr_accessor :tabSize # type: number
-    attr_accessor :insertSpaces # type: boolean
-    attr_accessor :trimTrailingWhitespace # type: boolean
-    attr_accessor :insertFinalNewline # type: boolean
-    attr_accessor :trimFinalNewlines # type: boolean
+    attr_accessor :tabSize, :insertSpaces, :trimTrailingWhitespace, :insertFinalNewline, :trimFinalNewlines # type: number # type: boolean # type: boolean # type: boolean # type: boolean
 
     def initialize(initial_hash = nil)
       super
@@ -1462,10 +1375,7 @@ module LSP
   #     data?: any;
   # }
   class DocumentLink < LSPBase
-    attr_accessor :range # type: Range
-    attr_accessor :target # type: string
-    attr_accessor :tooltip # type: string
-    attr_accessor :data # type: any
+    attr_accessor :range, :target, :tooltip, :data # type: Range # type: string # type: string # type: any
 
     def initialize(initial_hash = nil)
       super
@@ -1493,8 +1403,7 @@ module LSP
   #     parent?: SelectionRange;
   # }
   class SelectionRange < LSPBase
-    attr_accessor :range # type: Range
-    attr_accessor :parent # type: SelectionRange
+    attr_accessor :range, :parent # type: Range # type: SelectionRange
 
     def initialize(initial_hash = nil)
       super
@@ -1570,10 +1479,7 @@ module LSP
   #     readonly lineCount: number;
   # }
   class TextDocument < LSPBase
-    attr_accessor :uri # type: DocumentUri
-    attr_accessor :languageId # type: string
-    attr_accessor :version # type: number
-    attr_accessor :lineCount # type: number
+    attr_accessor :uri, :languageId, :version, :lineCount # type: DocumentUri # type: string # type: number # type: number
 
     def from_h!(value)
       value = {} if value.nil?
@@ -1612,8 +1518,7 @@ module LSP
   #     reason: 1 | 2 | 3;
   # }
   class TextDocumentWillSaveEvent < LSPBase
-    attr_accessor :document # type: TextDocument
-    attr_accessor :reason # type: 1 | 2 | 3
+    attr_accessor :document, :reason # type: TextDocument # type: 1 | 2 | 3
 
     def from_h!(value)
       value = {} if value.nil?

--- a/lib/puppet-debugserver/debug_session/flow_control.rb
+++ b/lib/puppet-debugserver/debug_session/flow_control.rb
@@ -56,7 +56,8 @@ module PuppetDebugServer
           @flags[flag_name] = true
           PuppetDebugServer.log_message(:debug, "Asserting flag #{flag_name} is true")
           # Any custom logic for when flags are asserted
-          if flag_name == :client_completed_configuration || flag_name == :session_setup # rubocop:disable Style/MultipleComparison  This is faster and doesn't require creation of an array
+          # rubocop:disable Style/MultipleComparison, Style/SoleNestedConditional This is faster and doesn't require creation of an array
+          if flag_name == :client_completed_configuration || flag_name == :session_setup
             # If the client_completed_configuration and session_setup flag are asserted but the session isn't active yet
             # assert the flag start_puppet so puppet can start in the main thread.
             if !@flags[:puppet_started] && @flags[:client_completed_configuration] && @flags[:session_setup]
@@ -67,6 +68,7 @@ module PuppetDebugServer
           @terminate_flag = true if flag_name == :terminate
         end
       end
+      # rubocop:enable Style/MultipleComparison, Style/SoleNestedConditional
 
       # Removes/unasserts a flag
       #

--- a/lib/puppet-debugserver/message_handler.rb
+++ b/lib/puppet-debugserver/message_handler.rb
@@ -4,10 +4,6 @@ require 'puppet_editor_services/handler/debug_adapter'
 
 module PuppetDebugServer
   class MessageHandler < PuppetEditorServices::Handler::DebugAdapter
-    def initialize(*_options)
-      super
-    end
-
     # region Message Helpers
     def send_exited_event(exitcode)
       protocol.encode_and_send(

--- a/lib/puppet-debugserver/puppet_debug_session.rb
+++ b/lib/puppet-debugserver/puppet_debug_session.rb
@@ -134,7 +134,7 @@ module PuppetDebugServer
 
       send_output_event(
         'category' => 'console',
-        'output'   => 'puppet ' + cmd_args.join(' ') + "\n"
+        'output'   => "puppet #{cmd_args.join(' ')}\n"
       )
       send_thread_event('started', @puppet_thread_id)
 

--- a/lib/puppet-languageserver-sidecar/cache/filesystem.rb
+++ b/lib/puppet-languageserver-sidecar/cache/filesystem.rb
@@ -97,7 +97,7 @@ module PuppetLanguageServerSidecar
       end
 
       def cache_filename(file_key)
-        Digest::SHA256.hexdigest(file_key) + '.txt'
+        "#{Digest::SHA256.hexdigest(file_key)}.txt"
       end
 
       def calculate_hash(filepath)

--- a/lib/puppet-languageserver-sidecar/puppet_modulepath_monkey_patches.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_modulepath_monkey_patches.rb
@@ -62,7 +62,7 @@ class Puppet::Node::Environment # rubocop:disable Style/ClassAndModuleChildren
         module_name = metadata['name']
       elsif Puppet::Module.is_module_namespaced_name?(metadata['name'])
         # Based on regex at https://github.com/puppetlabs/puppet/blob/f5ca8c05174c944f783cfd0b18582e2160b77d0e/lib/puppet/module.rb#L54
-        result = /^[a-zA-Z0-9]+[-]([a-z][a-z0-9_]*)$/.match(metadata['name'])
+        result = /^[a-zA-Z0-9]+-([a-z][a-z0-9_]*)$/.match(metadata['name'])
         module_name = result[1]
       else
         # TODO: This is an invalid puppet module name in the metadata.json.  Should we log an error/warning?

--- a/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb
@@ -255,7 +255,7 @@ module PuppetLanguageServerSidecar
         pre_docs += "This uses the legacy Ruby function API\n" if item[:type] == 'ruby3x'
         since_tag = item[:docstring][:tags].find { |tag| tag[:tag_name] == 'since' }
         pre_docs += "Since #{since_tag[:text]}\n" unless since_tag.nil?
-        obj.doc = pre_docs + "\n" + obj.doc unless pre_docs.empty?
+        obj.doc = "#{pre_docs}\n#{obj.doc}" unless pre_docs.empty?
 
         @cache[source_path].functions << obj
       end
@@ -309,13 +309,13 @@ module PuppetLanguageServerSidecar
         if name.start_with?('*') || name.start_with?('&')
           name.insert(1, '$')
         else
-          name = '$' + name
+          name = "$#{name}"
         end
 
         # We need to use terminating characters here due to substring matching e.g. $abc will incorrectly match in
         # function([String] $abc123, [String] $abc)
-        idx = sig.key.index(name + ',')
-        idx = sig.key.index(name + ')') if idx.nil?
+        idx = sig.key.index("#{name},")
+        idx = sig.key.index("#{name})") if idx.nil?
 
         unless idx.nil?
           param.signature_key_offset = idx

--- a/lib/puppet-languageserver-sidecar/puppet_strings_monkey_patches.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_strings_monkey_patches.rb
@@ -4,7 +4,7 @@ require 'yard/logging'
 module YARD
   class Logger < ::Logger
     # Suppress ANY output
-    def self.instance(_pipe = STDOUT)
+    def self.instance(_pipe = $stdout)
       @logger ||= new(nil)
     end
 

--- a/lib/puppet-languageserver/client_session_state.rb
+++ b/lib/puppet-languageserver/client_session_state.rb
@@ -6,13 +6,7 @@ require 'puppet-languageserver/session_state/object_cache'
 
 module PuppetLanguageServer
   class ClientSessionState
-    attr_reader :documents
-
-    attr_reader :language_client
-
-    attr_reader :object_cache
-
-    attr_reader :connection_id
+    attr_reader :documents, :language_client, :object_cache, :connection_id
 
     def initialize(message_handler, options = {})
       @documents       = options[:documents].nil? ? PuppetLanguageServer::SessionState::DocumentStore.new : options[:documents]

--- a/lib/puppet-languageserver/global_queues/sidecar_queue.rb
+++ b/lib/puppet-languageserver/global_queues/sidecar_queue.rb
@@ -7,10 +7,7 @@ require 'open3'
 module PuppetLanguageServer
   module GlobalQueues
     class SidecarQueueJob < SingleInstanceQueueJob
-      attr_accessor :action
-      attr_accessor :additional_args
-      attr_accessor :handle_errors
-      attr_accessor :connection_id
+      attr_accessor :action, :additional_args, :handle_errors, :connection_id
 
       def initialize(action, additional_args, handle_errors, connection_id)
         super("#{action}-#{connection_id}")

--- a/lib/puppet-languageserver/global_queues/validation_queue.rb
+++ b/lib/puppet-languageserver/global_queues/validation_queue.rb
@@ -6,10 +6,7 @@ require 'puppet_editor_services/server'
 module PuppetLanguageServer
   module GlobalQueues
     class ValidationQueueJob < SingleInstanceQueueJob
-      attr_accessor :file_uri
-      attr_accessor :doc_version
-      attr_accessor :connection_id
-      attr_accessor :options
+      attr_accessor :file_uri, :doc_version, :connection_id, :options
 
       def initialize(file_uri, doc_version, connection_id, options = {})
         super(file_uri)
@@ -51,7 +48,7 @@ module PuppetLanguageServer
         results = case document_store.document_type(job_object.file_uri)
                   when :manifest
                     options[:tasks_mode] = document_store.plan_file?(job_object.file_uri)
-                    PuppetLanguageServer:: Manifest::ValidationProvider.validate(session_state, content, options)
+                    PuppetLanguageServer::Manifest::ValidationProvider.validate(session_state, content, options)
                   when :epp
                     PuppetLanguageServer::Epp::ValidationProvider.validate(content)
                   when :puppetfile

--- a/lib/puppet-languageserver/manifest/completion_provider.rb
+++ b/lib/puppet-languageserver/manifest/completion_provider.rb
@@ -314,7 +314,7 @@ module PuppetLanguageServer
           unless param_type.nil?
             doc = ''
             doc += param_type[:type] unless param_type[:type].nil?
-            doc += "---\n" + param_type[:doc] unless param_type[:doc].nil?
+            doc += "---\n#{param_type[:doc]}" unless param_type[:doc].nil?
             result.documentation = doc
             result.insertText = "#{data['param']} => "
           end

--- a/lib/puppet-languageserver/manifest/definition_provider.rb
+++ b/lib/puppet-languageserver/manifest/definition_provider.rb
@@ -88,7 +88,7 @@ module PuppetLanguageServer
         item = PuppetLanguageServer::PuppetHelper.function(session_state, func_name)
         return nil if item.nil? || item.source.nil? || item.line.nil?
         LSP::Location.new(
-          'uri'   => 'file:///' + item.source,
+          'uri'   => "file:///#{item.source}",
           'range' => LSP.create_range(item.line, 0, item.line, 1024)
         )
       end

--- a/lib/puppet-languageserver/manifest/document_symbol_provider.rb
+++ b/lib/puppet-languageserver/manifest/document_symbol_provider.rb
@@ -118,7 +118,7 @@ module PuppetLanguageServer
         when 'Puppet::Pops::Model::ResourceBody'
           # We modify the parent symbol with the resource information,
           # mainly we care about the resource title.
-          parentsymbol.name = parentsymbol.name + ': ' + locator_text(object.title.offset, object.title.length, object.title.locator)
+          parentsymbol.name = "#{parentsymbol.name}: #{locator_text(object.title.offset, object.title.length, object.title.locator)}"
           parentsymbol.detail = parentsymbol.name
           parentsymbol.selectionRange = create_range(object.title.offset, object.title.length, object.locator)
 
@@ -146,9 +146,9 @@ module PuppetLanguageServer
           # Load in the class parameters
           object.parameters.each do |param|
             param_symbol = LSP::DocumentSymbol.new(
-              'name'           => '$' + param.name,
+              'name'           => "$#{param.name}",
               'kind'           => LSP::SymbolKind::PROPERTY,
-              'detail'         => '$' + param.name,
+              'detail'         => "$#{param.name}",
               'range'          => create_range(param.offset, param.length, param.locator),
               'selectionRange' => create_range(param.offset, param.length, param.locator),
               'children'       => []
@@ -169,9 +169,9 @@ module PuppetLanguageServer
           # Load in the class parameters
           object.parameters.each do |param|
             param_symbol = LSP::DocumentSymbol.new(
-              'name'           => '$' + param.name,
+              'name'           => "$#{param.name}",
               'kind'           => LSP::SymbolKind::FIELD,
-              'detail'         => '$' + param.name,
+              'detail'         => "$#{param.name}",
               'range'          => create_range(param.offset, param.length, param.locator),
               'selectionRange' => create_range(param.offset, param.length, param.locator),
               'children'       => []
@@ -181,9 +181,9 @@ module PuppetLanguageServer
 
         when 'Puppet::Pops::Model::AssignmentExpression'
           this_symbol = LSP::DocumentSymbol.new(
-            'name'           => '$' + object.left_expr.expr.value,
+            'name'           => "$#{object.left_expr.expr.value}",
             'kind'           => LSP::SymbolKind::VARIABLE,
-            'detail'         => '$' + object.left_expr.expr.value,
+            'detail'         => "$#{object.left_expr.expr.value}",
             'range'          => create_range(object.left_expr.offset, object.left_expr.length, object.left_expr.locator),
             'selectionRange' => create_range(object.left_expr.offset, object.left_expr.length, object.left_expr.locator),
             'children'       => []
@@ -202,9 +202,9 @@ module PuppetLanguageServer
           # Load in the class parameters
           object.parameters.each do |param|
             param_symbol = LSP::DocumentSymbol.new(
-              'name'           => '$' + param.name,
+              'name'           => "$#{param.name}",
               'kind'           => LSP::SymbolKind::CLASS,
-              'detail'         => '$' + param.name,
+              'detail'         => "$#{param.name}",
               'range'          => create_range(param.offset, param.length, param.locator),
               'selectionRange' => create_range(param.offset, param.length, param.locator),
               'children'       => []

--- a/lib/puppet-languageserver/manifest/format_on_type_provider.rb
+++ b/lib/puppet-languageserver/manifest/format_on_type_provider.rb
@@ -18,9 +18,7 @@ module PuppetLanguageServer
         # Abort if the formatting is tab based. Can't do that yet
         return result unless formatting_options['insertSpaces'] == true
         # Abort if content is too big
-        unless max_filesize.zero?
-          return result if content.length > max_filesize
-        end
+        return result if !max_filesize.zero? && (content.length > max_filesize)
 
         lexer = PuppetLint::Lexer.new
         tokens = lexer.tokenise(content)

--- a/lib/puppet-languageserver/manifest/hover_provider.rb
+++ b/lib/puppet-languageserver/manifest/hover_provider.rb
@@ -24,11 +24,11 @@ module PuppetLanguageServer
         when 'Puppet::Pops::Model::ResourceExpression'
           content = get_resource_expression_content(session_state, item)
         when 'Puppet::Pops::Model::LiteralString'
-          if path[-1].class == Puppet::Pops::Model::AccessExpression
+          if path[-1].instance_of?(Puppet::Pops::Model::AccessExpression)
             expr = path[-1].left_expr.expr.value
 
             content = get_hover_content_for_access_expression(session_state, path, expr)
-          elsif path[-1].class == Puppet::Pops::Model::ResourceBody
+          elsif path[-1].instance_of?(Puppet::Pops::Model::ResourceBody)
             # We are hovering over the resource name
             content = get_resource_expression_content(session_state, path[-2])
           end
@@ -54,9 +54,10 @@ module PuppetLanguageServer
           unless resource_object.nil?
             # Check if it's a property
             attribute = resource_object.attributes[item.attribute_name.intern]
-            if attribute[:type] == :property
+            case attribute[:type]
+            when :property
               content = get_attribute_type_property_content(resource_object, item.attribute_name.intern)
-            elsif attribute[:type] == :param
+            when :param
               content = get_attribute_type_parameter_content(resource_object, item.attribute_name.intern)
             end
           end
@@ -118,7 +119,7 @@ module PuppetLanguageServer
         content = "**#{factname}** Fact\n\n"
 
         if value.is_a?(Hash)
-          content = content + "```\n" + JSON.pretty_generate(value) + "\n```"
+          content = "#{content}```\n#{JSON.pretty_generate(value)}\n```"
         else
           content += value.to_s
         end
@@ -156,7 +157,7 @@ module PuppetLanguageServer
         raise "Function #{func_name} does not exist" if func_info.nil?
 
         content = "**#{func_name}** Function"
-        content += "\n\n" + func_info.doc unless func_info.doc.nil?
+        content += "\n\n#{func_info.doc}" unless func_info.doc.nil?
 
         content
       end
@@ -204,7 +205,7 @@ module PuppetLanguageServer
 
         content = "**#{item.cased_value}** Data Type"
         content += ' Alias' if dt_info.is_type_alias
-        content += "\n\n" + dt_info.doc unless dt_info.doc.nil?
+        content += "\n\n#{dt_info.doc}" unless dt_info.doc.nil?
 
         content += "\n\nAlias of `#{dt_info.alias_of}`" if dt_info.is_type_alias
         content

--- a/lib/puppet-languageserver/message_handler.rb
+++ b/lib/puppet-languageserver/message_handler.rb
@@ -82,7 +82,7 @@ module PuppetLanguageServer
       resource_list = PuppetLanguageServer::PuppetHelper.get_puppet_resource(session_state, type_name, title, documents.store_root_path)
       return LSP::PuppetResourceResponse.new('data' => '') if resource_list.nil? || resource_list.length.zero?
 
-      content = resource_list.map(&:manifest).join("\n\n") + "\n"
+      content = "#{resource_list.map(&:manifest).join("\n\n")}\n"
       LSP::PuppetResourceResponse.new('data' => content)
     end
 

--- a/lib/puppet-languageserver/puppet_helper.rb
+++ b/lib/puppet-languageserver/puppet_helper.rb
@@ -26,7 +26,7 @@ module PuppetLanguageServer
         ap = PuppetLanguageServer::Sidecar::Protocol::ActionParams.new
         ap['source'] = filepath
 
-        args = ['--action-parameters=' + ap.to_json]
+        args = ["--action-parameters=#{ap.to_json}"]
         args << "--local-workspace=#{local_workspace}" unless local_workspace.nil?
 
         sidecar_queue.execute('node_graph', args, false, session_state.connection_id)
@@ -38,7 +38,7 @@ module PuppetLanguageServer
       ap['typename'] = typename
       ap['title'] = title unless title.nil?
 
-      args = ['--action-parameters=' + ap.to_json]
+      args = ["--action-parameters=#{ap.to_json}"]
       args << "--local-workspace=#{local_workspace}" unless local_workspace.nil?
 
       sidecar_queue.execute('resource_list', args, false, session_state.connection_id)

--- a/lib/puppet-languageserver/puppet_parser_helper.rb
+++ b/lib/puppet-languageserver/puppet_parser_helper.rb
@@ -7,9 +7,7 @@ module PuppetLanguageServer
       raise if line_offset.nil?
 
       # Remove the offending character
-      new_content = content.slice(0, line_offset + char_num - num_chars_to_remove) + content.slice(line_offset + char_num, content.length - num_chars_to_remove)
-
-      new_content
+      content.slice(0, line_offset + char_num - num_chars_to_remove) + content.slice(line_offset + char_num, content.length - num_chars_to_remove)
     end
 
     def self.remove_char_at(content, line_offsets, line_num, char_num)
@@ -31,9 +29,7 @@ module PuppetLanguageServer
       line_offset = line_offsets[line_num]
       raise if line_offset.nil?
       # Insert the text
-      new_content = content.slice(0, line_offset + char_num) + text + content.slice(line_offset + char_num, content.length - 1)
-
-      new_content
+      content.slice(0, line_offset + char_num) + text + content.slice(line_offset + char_num, content.length - 1)
     end
 
     def self.line_offsets(content)

--- a/lib/puppet-languageserver/session_state/document_store.rb
+++ b/lib/puppet-languageserver/session_state/document_store.rb
@@ -5,10 +5,7 @@ module PuppetLanguageServer
     # Represents a Document in the Document Store.
     # Can be subclassed to add additional methods and helpers
     class Document
-      attr_reader :uri
-      attr_reader :content
-      attr_reader :version
-      attr_reader :tokens
+      attr_reader :uri, :content, :version, :tokens
 
       # @param uri String The content of the document
       # @param content String The content of the document
@@ -129,7 +126,7 @@ module PuppetLanguageServer
         return false if uri_path.nil?
         # For the text searching below we need a leading slash. That way
         # we don't need to use regexes which is slower
-        uri_path = '/' + uri_path unless uri_path.start_with?('/')
+        uri_path = "/#{uri_path}" unless uri_path.start_with?('/')
         if windows?
           plans_index = uri_path.upcase.index('/PLANS/')
           manifests_index = uri_path.upcase.index('/MANIFESTS/')

--- a/lib/puppet-languageserver/session_state/language_client.rb
+++ b/lib/puppet-languageserver/session_state/language_client.rb
@@ -3,14 +3,10 @@
 module PuppetLanguageServer
   module SessionState
     class LanguageClient
-      attr_reader :message_handler
+      attr_reader :message_handler, :format_on_type_filesize_limit, :folding_range, :folding_range_show_last_line, :use_puppetfile_resolver
 
       # Client settings
       attr_reader :format_on_type
-      attr_reader :format_on_type_filesize_limit
-      attr_reader :folding_range
-      attr_reader :folding_range_show_last_line
-      attr_reader :use_puppetfile_resolver
 
       DEFAULT_FORMAT_ON_TYPE_ENABLE = false
       DEFAULT_FORMAT_ON_TYPE_FILESIZE_LIMIT = 4096

--- a/lib/puppet-languageserver/session_state/object_cache.rb
+++ b/lib/puppet-languageserver/session_state/object_cache.rb
@@ -90,9 +90,9 @@ module PuppetLanguageServer
         return true if value == test_string
 
         # Test for a shortname
-        unless test_string.start_with?('::')
+        if !test_string.start_with?('::') && value.end_with?("::#{test_string}")
           # e.g 'TargetSpec' in 'Boltlib::TargetSpec'
-          return true if value.end_with?('::' + test_string)
+          return true
         end
 
         false

--- a/lib/puppet-languageserver/sidecar_protocol.rb
+++ b/lib/puppet-languageserver/sidecar_protocol.rb
@@ -84,12 +84,7 @@ module PuppetLanguageServer
       # char           => The character number in the source file where the object was created
       # length         => The length of characters from `char` in the source file where the object was created
       class BasePuppetObject < BaseClass
-        attr_accessor :key
-        attr_accessor :calling_source
-        attr_accessor :source
-        attr_accessor :line
-        attr_accessor :char
-        attr_accessor :length
+        attr_accessor :key, :calling_source, :source, :line, :char, :length
 
         def to_h
           {
@@ -124,7 +119,7 @@ module PuppetLanguageServer
         include Base
 
         def to_json(*options)
-          '[' + map { |item| item.to_json(options) }.join(',') + ']'
+          "[#{map { |item| item.to_json(options) }.join(',')}]"
         end
 
         def from_json!(json_string)
@@ -142,9 +137,7 @@ module PuppetLanguageServer
       end
 
       class PuppetNodeGraph < BaseClass
-        attr_accessor :vertices
-        attr_accessor :edges
-        attr_accessor :error_content
+        attr_accessor :vertices, :edges, :error_content
 
         def to_json(*options)
           {
@@ -164,8 +157,7 @@ module PuppetLanguageServer
       end
 
       class PuppetClass < BasePuppetObject
-        attr_accessor :parameters
-        attr_accessor :doc
+        attr_accessor :parameters, :doc
 
         def to_h
           super.to_h.merge(
@@ -199,10 +191,7 @@ module PuppetLanguageServer
       end
 
       class PuppetDataType < BasePuppetObject
-        attr_accessor :doc
-        attr_accessor :alias_of
-        attr_accessor :attributes
-        attr_accessor :is_type_alias
+        attr_accessor :doc, :alias_of, :attributes, :is_type_alias
 
         def initialize
           super
@@ -236,10 +225,7 @@ module PuppetLanguageServer
       end
 
       class PuppetDataTypeAttribute < BaseClass
-        attr_accessor :key
-        attr_accessor :doc
-        attr_accessor :default_value
-        attr_accessor :types
+        attr_accessor :key, :doc, :default_value, :types
 
         def to_h
           {
@@ -266,10 +252,9 @@ module PuppetLanguageServer
       end
 
       class PuppetFunction < BasePuppetObject
-        attr_accessor :doc
+        attr_accessor :doc, :signatures
         # The version of this function, typically 3 or 4.
         attr_accessor :function_version
-        attr_accessor :signatures
 
         def initialize
           super
@@ -301,10 +286,7 @@ module PuppetLanguageServer
       end
 
       class PuppetFunctionSignature < BaseClass
-        attr_accessor :key
-        attr_accessor :doc
-        attr_accessor :return_types
-        attr_accessor :parameters
+        attr_accessor :key, :doc, :return_types, :parameters
 
         def initialize
           super
@@ -336,11 +318,7 @@ module PuppetLanguageServer
       end
 
       class PuppetFunctionSignatureParameter < BaseClass
-        attr_accessor :name
-        attr_accessor :types
-        attr_accessor :doc
-        attr_accessor :signature_key_offset # Zero based offset where this parameter exists in the signature key
-        attr_accessor :signature_key_length # The length of text where this parameter exists in the signature key
+        attr_accessor :name, :types, :doc, :signature_key_offset, :signature_key_length # Zero based offset where this parameter exists in the signature key # The length of text where this parameter exists in the signature key
 
         def to_h
           {
@@ -369,8 +347,7 @@ module PuppetLanguageServer
       end
 
       class PuppetType < BasePuppetObject
-        attr_accessor :doc
-        attr_accessor :attributes
+        attr_accessor :doc, :attributes
 
         def to_h
           super.to_h.merge(
@@ -483,9 +460,9 @@ module PuppetLanguageServer
           self
         end
 
-        def each_list
+        def each_list(&block)
           return unless block_given?
-          @aggregate.each { |k, v| yield k, v }
+          @aggregate.each(&block)
         end
 
         private

--- a/lib/puppet-languageserver/uri_helper.rb
+++ b/lib/puppet-languageserver/uri_helper.rb
@@ -9,7 +9,7 @@ module PuppetLanguageServer
       if path.nil?
         nil
       else
-        'file://' + Puppet::Util.uri_encode(path.start_with?('/') ? path : '/' + path)
+        "file://#{Puppet::Util.uri_encode(path.start_with?('/') ? path : "/#{path}")}"
       end
     end
 

--- a/lib/puppet_editor_services/connection/base.rb
+++ b/lib/puppet_editor_services/connection/base.rb
@@ -3,8 +3,7 @@
 module PuppetEditorServices
   module Connection
     class Base
-      attr_reader :server
-      attr_reader :protocol
+      attr_reader :server, :protocol
 
       def initialize(server)
         @server = server

--- a/lib/puppet_editor_services/handler/debug_adapter.rb
+++ b/lib/puppet_editor_services/handler/debug_adapter.rb
@@ -6,10 +6,6 @@ require 'puppet_editor_services/protocol/debug_adapter_messages'
 module PuppetEditorServices
   module Handler
     class DebugAdapter < ::PuppetEditorServices::Handler::Base
-      def initialize(protocol)
-        super(protocol)
-      end
-
       # options
       #    source        :request, :notification etc.
       #    message       JSON Message that caused the error
@@ -60,8 +56,7 @@ module PuppetEditorServices
       end
 
       def rpc_name_to_ruby_method_name(prefix, rpc_name)
-        name = prefix + '_' + rpc_name.tr('/', '_').tr('$', 'dollar').downcase
-        name
+        "#{prefix}_#{rpc_name.tr('/', '_').tr('$', 'dollar').downcase}"
       end
     end
   end

--- a/lib/puppet_editor_services/handler/json_rpc.rb
+++ b/lib/puppet_editor_services/handler/json_rpc.rb
@@ -6,10 +6,6 @@ require 'puppet_editor_services/protocol/json_rpc_messages'
 module PuppetEditorServices
   module Handler
     class JsonRPC < ::PuppetEditorServices::Handler::Base
-      def initialize(protocol)
-        super(protocol)
-      end
-
       # options
       #    source        :request, :notification etc.
       #    message       JSON Message that caused the error
@@ -129,8 +125,7 @@ module PuppetEditorServices
       end
 
       def rpc_name_to_ruby_method_name(prefix, rpc_name)
-        name = prefix + '_' + rpc_name.tr('/', '_').tr('$', 'dollar').downcase
-        name
+        "#{prefix}_#{rpc_name.tr('/', '_').tr('$', 'dollar').downcase}"
       end
     end
   end

--- a/lib/puppet_editor_services/protocol/base.rb
+++ b/lib/puppet_editor_services/protocol/base.rb
@@ -3,8 +3,7 @@
 module PuppetEditorServices
   module Protocol
     class Base
-      attr_reader :connection
-      attr_reader :handler
+      attr_reader :connection, :handler
 
       def initialize(connection)
         @connection = connection

--- a/lib/puppet_editor_services/protocol/debug_adapter_messages.rb
+++ b/lib/puppet_editor_services/protocol/debug_adapter_messages.rb
@@ -13,8 +13,7 @@ module PuppetEditorServices
       #         type: string;
       #     }
       class ProtocolMessage
-        attr_accessor :seq # type: number
-        attr_accessor :type # type: string
+        attr_accessor :seq, :type # type: number # type: string
 
         def initialize(initial_hash = nil)
           from_h!(initial_hash)
@@ -46,8 +45,7 @@ module PuppetEditorServices
       #         arguments?: any;
       #     }
       class Request < ProtocolMessage
-        attr_accessor :command # type: string
-        attr_accessor :arguments # type: any
+        attr_accessor :command, :arguments # type: string # type: any
 
         def initialize(initial_hash = nil)
           super
@@ -77,8 +75,7 @@ module PuppetEditorServices
       #         body?: any;
       #     }
       class Event < ProtocolMessage
-        attr_accessor :event # type: string
-        attr_accessor :body # type: any
+        attr_accessor :event, :body # type: string # type: any
 
         def initialize(initial_hash = nil)
           super
@@ -114,11 +111,7 @@ module PuppetEditorServices
       #         body?: any;
       #     }
       class Response < ProtocolMessage
-        attr_accessor :request_seq # type: number
-        attr_accessor :success # type: boolean
-        attr_accessor :command # type: string
-        attr_accessor :message # type: string
-        attr_accessor :body # type: any
+        attr_accessor :request_seq, :success, :command, :message, :body # type: number # type: boolean # type: string # type: string # type: any
 
         def initialize(initial_hash = nil)
           super

--- a/lib/puppet_editor_services/protocol/json_rpc.rb
+++ b/lib/puppet_editor_services/protocol/json_rpc.rb
@@ -153,27 +153,21 @@ module PuppetEditorServices
         is_response = json_obj.key?(KEY_ID) && !json_obj.key?(KEY_METHOD) && (json_obj.key?(KEY_RESULT) || json_obj.key?(KEY_ERROR))
 
         # The 'params' attribute must be a hash or an array
-        if (params = json_obj[KEY_PARAMS])
-          unless params.is_a?(Array) || params.is_a?(Hash)
-            reply_error id, CODE_INVALID_REQUEST, MSG_INVALID_REQ_PARAMS
-            return false
-          end
+        if (params = json_obj[KEY_PARAMS]) && !(params.is_a?(Array) || params.is_a?(Hash))
+          reply_error id, CODE_INVALID_REQUEST, MSG_INVALID_REQ_PARAMS
+          return false
         end
 
         # Requests and Responses must have an ID that is either a string or integer
-        if is_request || is_response
-          unless id.is_a?(String) || id.is_a?(Integer)
-            reply_error nil, CODE_INVALID_REQUEST, MSG_INVALID_REQ_ID
-            return false
-          end
+        if (is_request || is_response) && !(id.is_a?(String) || id.is_a?(Integer))
+          reply_error nil, CODE_INVALID_REQUEST, MSG_INVALID_REQ_ID
+          return false
         end
 
         # Requests and Notifications must have a method
-        if is_request || is_notification
-          unless (json_obj[KEY_METHOD]).is_a? String
-            reply_error id, CODE_INVALID_REQUEST, MSG_INVALID_REQ_METHOD
-            return false
-          end
+        if (is_request || is_notification) && !((json_obj[KEY_METHOD]).is_a? String)
+          reply_error id, CODE_INVALID_REQUEST, MSG_INVALID_REQ_METHOD
+          return false
         end
 
         # Responses must have a matching request originating from this instance

--- a/lib/puppet_editor_services/protocol/json_rpc_messages.rb
+++ b/lib/puppet_editor_services/protocol/json_rpc_messages.rb
@@ -49,9 +49,7 @@ module PuppetEditorServices
       #   params?: Array<any> | object;
       # }
       class RequestMessage < Message
-        attr_accessor :id
-        attr_accessor :rpc_method
-        attr_accessor :params
+        attr_accessor :id, :rpc_method, :params
 
         def initialize(initial_hash = nil)
           super
@@ -87,8 +85,7 @@ module PuppetEditorServices
       #   params?: Array<any> | object;
       # }
       class NotificationMessage < Message
-        attr_accessor :rpc_method
-        attr_accessor :params
+        attr_accessor :rpc_method, :params
 
         def initialize(initial_hash = nil)
           super
@@ -127,9 +124,7 @@ module PuppetEditorServices
       #   error?: ResponseError<any>;
       # }
       class ResponseMessage < Message
-        attr_accessor :id
-        attr_accessor :result
-        attr_accessor :error
+        attr_accessor :id, :result, :error
         # is_successful is special. It changes based on deserialising from hash or
         # can be manually set. This affects serialisation
         attr_accessor :is_successful

--- a/lib/puppet_editor_services/server/base.rb
+++ b/lib/puppet_editor_services/server/base.rb
@@ -7,10 +7,7 @@ require 'puppet_editor_services/protocol/base'
 module PuppetEditorServices
   module Server
     class Base
-      attr_reader :server_options
-      attr_reader :connection_options
-      attr_reader :protocol_options
-      attr_reader :handler_options
+      attr_reader :server_options, :connection_options, :protocol_options, :handler_options
 
       def name
         'SRV'

--- a/lib/puppet_editor_services/server/tcp.rb
+++ b/lib/puppet_editor_services/server/tcp.rb
@@ -17,13 +17,7 @@ module PuppetEditorServices
   module Server
     class Tcp < ::PuppetEditorServices::Server::Base
       class << self
-        attr_reader :io_locker
-        attr_reader :events
-        attr_reader :e_locker
-        attr_reader :services
-        attr_reader :s_locker
-        attr_reader :io_connection_dic
-        attr_reader :c_locker
+        attr_reader :io_locker, :events, :e_locker, :services, :s_locker, :io_connection_dic, :c_locker
       end
 
       @io_locker = Mutex.new

--- a/lib/puppet_languageserver_sidecar.rb
+++ b/lib/puppet_languageserver_sidecar.rb
@@ -347,8 +347,8 @@ module PuppetLanguageServerSidecar
 
   def self.output(result, options)
     if options[:output].nil? || options[:output].empty?
-      STDOUT.binmode
-      STDOUT.write(result.to_json)
+      $stdout.binmode
+      $stdout.write(result.to_json)
     else
       File.open(options[:output], 'wb:UTF-8') do |f|
         f.write result.to_json


### PR DESCRIPTION
Prior to this PR, the puppetlabs-editor-services repo was using an out of date version of the rubocop gem.

This PR updates the gem to use a version more in-line with the rest of our repositories, and fixes violations that were present after the update.
