### PR TITLE
(CONT-988) Update actions/upload-artifact version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Run rake gem_revendor build
         run: bundle exec rake gem_revendor build
       - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: puppet-editor-services
           path: output/*.zip

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Run rake gem_revendor build
         run: bundle exec rake gem_revendor build
       - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: puppet-editor-services
           path: output/*.zip


### PR DESCRIPTION
The deprecation warning for actions/upload-artifact@v2 was missed in the previous PR. This PR updates this to remove the deprecation warning for the workflow.
