### PR TITLE
(maint) - Pin ffi to 1.15.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :development do
   gem 'puppet-lint', '~> 4.0',            :require => false
   gem 'puppetfile-resolver', '~> 0.6.2',  :require => false
   gem 'yard', '~> 0.9.28',                :require => false
-  gem 'ffi', '= 1.15.2',                  :require => false
+  gem 'ffi', '= 1.15.5',                  :require => false
   gem "rubocop", '~> 1.48.1',                          require: false
   gem "rubocop-performance", '~> 1.16',                require: false
   gem "rubocop-rspec", '~> 2.19',                      require: false


### PR DESCRIPTION
## Summary
Updating to be consistent with version of ffi gem pulled in by puppet runtime. https://github.com/puppetlabs/puppet/pull/9112/files
