### PR TITLE
(CAT-1595) - Remove diagnostic on textDoucment onDidClose

### DIFF
--- a/lib/puppet-languageserver/global_queues/validation_queue.rb
+++ b/lib/puppet-languageserver/global_queues/validation_queue.rb
@@ -35,16 +35,16 @@ module PuppetLanguageServer
         session_state = session_state_from_connection_id(job_object.connection_id)
         document_store = session_state.nil? ? nil : session_state.documents
         raise "Document store is not available for connection id #{job_object.connection_id}" unless document_store
-        
+
         # Check if the document still exists
         doc = document_store.get_document(job_object.file_uri)
         unless doc
           # Send an empty diagnostics message to clear the diagnostics
-          send_remove_diagnostic(job_object.connection_id, job_object.file_uri, nil)
+          send_diagnostics(job_object.connection_id, job_object.file_uri, [])
           PuppetLanguageServer.log_message(:debug, "#{self.class.name}: Ignoring #{job_object.file_uri} as it is has been removed.")
           return
         end
-        
+
         # Check if the document is the latest version
         content = document_store.document_content(job_object.file_uri, job_object.doc_version)
         unless content
@@ -95,15 +95,6 @@ module PuppetLanguageServer
 
         connection.protocol.encode_and_send(
           ::PuppetEditorServices::Protocol::JsonRPCMessages.new_notification('textDocument/publishDiagnostics', 'uri' => file_uri, 'diagnostics' => diagnostics)
-        )
-      end
-
-      def send_remove_diagnostic(connection_id, file_uri, diagnostics)
-        connection = PuppetEditorServices::Server.current_server.connection(connection_id)
-        return if connection.nil?
-
-        connection.protocol.encode_and_send(
-          ::PuppetEditorServices::Protocol::JsonRPCMessages.new_notification('textDocument/publishDiagnostics', 'uri' => file_uri, 'diagnostics' => [])
         )
       end
     end

--- a/lib/puppet-languageserver/message_handler.rb
+++ b/lib/puppet-languageserver/message_handler.rb
@@ -331,9 +331,8 @@ module PuppetLanguageServer
     def notification_textdocument_didclose(client_handler_id, json_rpc_message)
       PuppetLanguageServer.log_message(:info, 'Received textDocument/didClose notification.')
       file_uri = json_rpc_message.params['textDocument']['uri']
-      doc_version = json_rpc_message.params['textDocument']['version']
       documents.remove_document(file_uri)
-      enqueue_validation(file_uri, doc_version, client_handler_id)
+      enqueue_validation(file_uri, nil, client_handler_id)
     end
 
     def notification_textdocument_didchange(client_handler_id, json_rpc_message)
@@ -392,8 +391,7 @@ module PuppetLanguageServer
 
     private
 
-    def enqueue_validation(file_uri, doc_version, client_handler_id)
-      options = {}
+    def enqueue_validation(file_uri, doc_version, client_handler_id, options = {})
       if documents.document_type(file_uri) == :puppetfile
         options[:resolve_puppetfile] = language_client.use_puppetfile_resolver
         options[:puppet_version]     = Puppet.version

--- a/lib/puppet-languageserver/message_handler.rb
+++ b/lib/puppet-languageserver/message_handler.rb
@@ -328,10 +328,12 @@ module PuppetLanguageServer
       enqueue_validation(file_uri, doc_version, client_handler_id)
     end
 
-    def notification_textdocument_didclose(_, json_rpc_message)
+    def notification_textdocument_didclose(client_handler_id, json_rpc_message)
       PuppetLanguageServer.log_message(:info, 'Received textDocument/didClose notification.')
       file_uri = json_rpc_message.params['textDocument']['uri']
+      doc_version = json_rpc_message.params['textDocument']['version']
       documents.remove_document(file_uri)
+      enqueue_validation(file_uri, doc_version, client_handler_id)
     end
 
     def notification_textdocument_didchange(client_handler_id, json_rpc_message)

--- a/lib/puppet-languageserver/session_state/document_store.rb
+++ b/lib/puppet-languageserver/session_state/document_store.rb
@@ -86,6 +86,11 @@ module PuppetLanguageServer
         doc.nil? ? nil : doc.content.clone
       end
 
+      def get_document(uri)
+        doc = @documents[uri]
+        doc.nil? ? nil : doc.content.clone
+      end
+
       def document_tokens(uri, doc_version = nil)
         @doc_mutex.synchronize do
           return nil if @documents[uri].nil?

--- a/spec/languageserver/unit/puppet-languageserver/global_queues/validation_queue_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/global_queues/validation_queue_spec.rb
@@ -176,8 +176,8 @@ describe 'PuppetLanguageServer::GlobalQueues::ValidationQueue' do
       allow(PuppetLanguageServer::Puppetfile::ValidationProvider).to receive(:validate).and_raise("PuppetLanguageServer::Puppetfile::ValidationProvider.validate mock should not be called")
     end
 
-    it 'should not send validation results for documents that do not exist' do
-      expect(subject).to_not receive(:send_diagnostics)
+    it 'should send empty validation results for documents that do not exist' do
+      expect(subject).to receive(:send_diagnostics).with(connection_id, VALIDATE_MISSING_FILENAME, [])
 
       subject.execute(VALIDATE_MISSING_FILENAME, 1, connection_id)
     end


### PR DESCRIPTION
## Summary
Prior to this PR, diagnostics (or "problems") in the vscode problems pane would not be removed on the closing of a file. This is bad practice, and quickly leads to a polluted problems pane with linting issues etc showing for all files despite being open or not.

This PR aims to fix this issue, by calling publishDiagnostics in the vscode API on the close of a text document with an empty array of diagnostics as per the vscode documentation.

This has been verified as working in local vscode setup.
**Before**
![Nov-24-2023 11-10-52](https://github.com/puppetlabs/puppet-editor-services/assets/112936862/5d4f3f02-35d7-4836-a49d-41feef43c7ef)

**After**
![Nov-24-2023 11-11-35](https://github.com/puppetlabs/puppet-editor-services/assets/112936862/d284ba37-cbfc-4d00-92cf-2cae101ecff4)


## Related Issues (if any)
Fixes https://github.com/puppetlabs/puppet-editor-services/issues/357

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
