### PR TITLE
Revert "(MAINT) - TEMP pin to FFI 1.15.2" and REVERT "(maint) - Pin ffi to 1.15.5"

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Setting ownership to the tooling team
-* @puppetlabs/tooling
+* @puppetlabs/devx

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ group :development do
   gem 'puppet-lint', '~> 4.0',            :require => false
   gem 'puppetfile-resolver', '~> 0.6.2',  :require => false
   gem 'yard', '~> 0.9.28',                :require => false
-  gem 'ffi', '= 1.15.5',                  :require => false
   gem "rubocop", '~> 1.48.1',             :require => false
   gem "rubocop-performance", '~> 1.16',   :require => false
   gem "rubocop-rspec", '~> 2.19',         :require => false


### PR DESCRIPTION
This reverts commit 4515c9d025ad3fdba5edc1e0f2541d76709eb776.
This also reverts the subsequent commit 18efae6eb1b333b412ec19f008913bf1f5fe3b2a. 

This issue has been since fixed upstream in puppet, so we can now remove these pins and the ffi gem.
## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
