### PR TITLE
(CAT-1669) - Add trailing comma to completion item

### DIFF
--- a/lib/puppet-languageserver/manifest/completion_provider.rb
+++ b/lib/puppet-languageserver/manifest/completion_provider.rb
@@ -291,7 +291,7 @@ module PuppetLanguageServer
           unless param_type.nil?
             # TODO: More things?
             result.documentation = param_type[:doc] unless param_type[:doc].nil?
-            result.insertText = "#{data['param']} => "
+            result.insertText = "#{data['param']} => ,"
           end
         when 'resource_property'
           item_type = PuppetLanguageServer::PuppetHelper.get_type(session_state, data['resource_type'])
@@ -301,7 +301,7 @@ module PuppetLanguageServer
           unless prop_type.nil?
             # TODO: More things?
             result.documentation = prop_type[:doc] unless prop_type[:doc].nil?
-            result.insertText = "#{data['prop']} => "
+            result.insertText = "#{data['prop']} => ,"
           end
 
         when 'resource_class'
@@ -320,7 +320,7 @@ module PuppetLanguageServer
             doc += param_type[:type] unless param_type[:type].nil?
             doc += "---\n#{param_type[:doc]}" unless param_type[:doc].nil?
             result.documentation = doc
-            result.insertText = "#{data['param']} => "
+            result.insertText = "#{data['param']} => ,"
           end
         end
 


### PR DESCRIPTION
## Summary
Prior to this PR, we would return completion items without a trailing comma. A trailing comma is the suggested style as per the puppet code docs, so we should append this to the returned value.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
