### PR TITLE
(maint) Exclude breaking rubocop versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ group :development do
   gem "rubocop", '~> 1.50.0',             :require => false
   gem "rubocop-performance", '~> 1.16',   :require => false
   gem "rubocop-rspec", '~> 2.19',         :require => false
+  gem 'rubocop-factory_bot', '!= 2.26.0', require: false
+  gem 'rubocop-rspec_rails', '!= 2.29.0', require: false
   gem 'simplecov',                        :require => false
   gem 'simplecov-console',                :require => false
 


### PR DESCRIPTION
The latest versions of [rubocop-factory_bot](https://github.com/rubocop/rubocop-factory_bot/tags) and [rubocop-respec_rails](https://github.com/rubocop/rubocop-rspec_rails/releases) are causing rubocop-rspec to break with something like the following:

```bash
➜  dependency_checker git:(main) bundle exec rubocop
Error: Property AutoCorrect of cop FactoryBot/CreateList is supposed to be a boolean and contextual is not.
➜  dependency_checker git:(main) 
```

Manually correcting the above gems fixes the issue with:


```diff
➜  gems git:(main) ✗ git diff
diff --git a/rubocop-factory_bot-2.26.0/config/default.yml b/rubocop-factory_bot-2.26.0/config/default.yml
index 24d5ebb..60827e7 100644
--- a/rubocop-factory_bot-2.26.0/config/default.yml
+++ b/rubocop-factory_bot-2.26.0/config/default.yml
@@ -49,7 +49,7 @@ FactoryBot/ConsistentParenthesesStyle:
 FactoryBot/CreateList:
   Description: Checks for create_list usage.
   Enabled: true
-  AutoCorrect: contextual
+  AutoCorrect: false
   Include:
     - "**/*_spec.rb"
     - "**/spec/**/*"
diff --git a/rubocop-rspec_rails-2.29.0/config/default.yml b/rubocop-rspec_rails-2.29.0/config/default.yml
index 51ec888..a39bd20 100644
--- a/rubocop-rspec_rails-2.29.0/config/default.yml
+++ b/rubocop-rspec_rails-2.29.0/config/default.yml
@@ -66,7 +66,7 @@ RSpecRails/MinitestAssertions:
 
 RSpecRails/NegationBeValid:
   Description: Enforces use of `be_invalid` or `not_to` for negated be_valid.
-  AutoCorrect: contextual
+  AutoCorrect: false
   Safe: false
   EnforcedStyle: not_to
   SupportedStyles:
➜  gems git:(main) ✗ pwd
/Users/gavin.didrichsen/@REFERENCES/github/app/development/tools/puppet/@products/devx_tools/repos/dependency_checker/.direnv/ruby/gems/ruby/3.3.0/gems
➜  gems git:(main) ✗ 
```

Therefore excluding the latest version until this is fixed.