### PR TITLE
Create a gem for puppet-editor-services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 Gemfile.lock
 Gemfile.local
+*.gem
 log/
 junit/
 .vagrant/

--- a/bin/puppet-debugserver
+++ b/bin/puppet-debugserver
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'puppet_debugserver'
+
+PuppetDebugServer.init_puppet(PuppetDebugServer::CommandLineParser.parse(ARGV))
+rpc_thread = PuppetDebugServer.rpc_server_async(PuppetDebugServer::CommandLineParser.parse(ARGV))
+PuppetDebugServer.execute(rpc_thread)

--- a/bin/puppet-languageserver
+++ b/bin/puppet-languageserver
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'puppet_languageserver'
+
+PuppetLanguageServer.init_puppet(PuppetLanguageServer::CommandLineParser.parse(ARGV))
+PuppetLanguageServer.rpc_server(PuppetLanguageServer::CommandLineParser.parse(ARGV))

--- a/bin/puppet-languageserver-sidecar
+++ b/bin/puppet-languageserver-sidecar
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'puppet_languageserver_sidecar'
+
+PuppetLanguageServerSidecar.init_puppet_sidecar(PuppetLanguageServerSidecar::CommandLineParser.parse(ARGV))
+PuppetLanguageServerSidecar.execute_and_output(PuppetLanguageServerSidecar::CommandLineParser.parse(ARGV))

--- a/puppet-editor-services.gemspec
+++ b/puppet-editor-services.gemspec
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require_relative 'lib/puppet_editor_services/version'
+require 'rake'
+
+Gem::Specification.new do |s|
+  s.name           = 'puppet-editor-services'
+  s.version        = PuppetEditorServices.version
+  s.authors        = ['Puppet']
+  s.email          = ['support@puppet.com']
+  s.summary       = 'Puppet Language Server for editors'
+  s.description = <<~EOF
+    A ruby based implementation of a Language Server and Debug Server for the
+    Puppet Language. Integrate this into your editor to benefit from full Puppet
+    Language support, such as syntax hightlighting, linting, hover support and more.
+  EOF
+  s.homepage    = 'https://github.com/puppetlabs/puppet-editor-services'
+  s.required_ruby_version = '>= 2.7.0'
+  s.executables = %w[ puppet-debugserver puppet-languageserver puppet-languageserver-sidecar ]
+  s.files          = FileList['lib/**/*.rb',
+                              'bin/*',
+                              '[A-Z]*'].to_a
+  s.license        = 'Apache-2.0'
+  s.add_runtime_dependency 'puppet-lint'
+  s.add_runtime_dependency 'hiera-eyaml'
+  s.add_runtime_dependency 'puppetfile-resolver'
+  s.add_runtime_dependency 'molinillo'
+  s.add_runtime_dependency 'puppet-strings'
+  s.add_runtime_dependency 'yard'
+end


### PR DESCRIPTION
## Summary
This PR adds a gemspec and executables that would be called from it. The three executables are variations of the same files that reside in the root of the repo.

## Additional Context
The idea here is to make it easier for people like myself to install a local copy of puppet-editor-services. This will facilitate easier use as a language server in things like neovim. Additionally, my hope is to use this gem as the basis for a [Nix package](https://nixos.org/manual/nixpkgs/stable/#packaging-applications) that I would maintain.

I do imagine that some more specific requirements could be added to the runtime dependencies listed in the gemspec - if you have feedback on that, I am happy to adjust.

## Checklist
I didn't do the check list because I didn't do any changes to the code, this is just setting up packaging.