### PR TITLE
Fix: Ruby 3.4 compatibility for JSON.generate

### DIFF
--- a/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb
@@ -370,7 +370,7 @@ module PuppetLanguageServerSidecar
     end
 
     def to_json(*options)
-      JSON.generate(to_h, options)
+      JSON.generate(to_h, *options)
     end
 
     # Deserialisation


### PR DESCRIPTION
## Summary

Ruby 3.4 compatibility: TypeError in puppet_strings_helper.rb

The puppet-languageserver-sidecar crashes on Ruby 3.4.7 when attempting to index Puppet types, preventing the LSP from providing information about native Puppet resources (package, user, file, etc.).

## Additional Context
Add any additional context about the problem here. 

- OS: Arch Linux (kernel 6.17.9)
- Ruby version: 3.4.7 (2025-10-08)
- Puppet version: 8.10.0 (gem)
- puppet-editor-services version: 2.0.4
- Installation method: Mason.nvim

## Steps to Reproduce

1. Install Ruby 3.4.7 (default on recent Arch Linux)
2. Install puppet-editor-services 2.0.4
3. Run the sidecar:
```bash
puppet-languageserver-sidecar --action=default_types
```

## Expected Behavior

The sidecar should return a JSON array of all Puppet native types with their documentation.

## Actual Behavior

The sidecar crashes with:

```
/usr/lib/ruby/3.4.0/json/common.rb:305:in `JSON::Ext::Generator::State.generate': 
wrong argument type Array (expected Hash) (TypeError)

      State.generate(obj, opts, nil)
                     ^^^^^^^^^^^^^^
	from /usr/lib/ruby/3.4.0/json/common.rb:305:in `JSON.generate'
	from lib/puppet-languageserver-sidecar/puppet_strings_helper.rb:373:in `to_json'
```

## Root Cause

In `lib/puppet-languageserver-sidecar/puppet_strings_helper.rb`, line 373:

```ruby
def to_json(*options)
  JSON.generate(to_h, options)  # Passes Array instead of unpacking
end
```

## Related Issues (if any)

N/A

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
